### PR TITLE
Build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ checkpatch-all-files: checkpatch-pre-req
 distclean: clean
 
 ifdef ROOTFS_DIR
-copy_rootfs:
+copy_rootfs: build
 	cp ${O}/libteec/libteec.so* ${ROOTFS_DIR}/usr/lib
 	cp ${O}/tee-supplicant/tee-supplicant ${ROOTFS_DIR}/usr/local/bin
 clean_rootfs:
@@ -131,7 +131,7 @@ clean_rootfs:
 	@echo Rootfs clean cannot be done because ROOTFS_DIR is not defined
 endif
 
-copy_export:
+copy_export: build
 	mkdir -p ${EXPORT_DIR}/lib ${EXPORT_DIR}/include ${EXPORT_DIR}/bin
 	cp ${O}/libteec/libteec.so* ${EXPORT_DIR}/lib
 	cp ${O}/tee-supplicant/tee-supplicant ${EXPORT_DIR}/bin

--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -30,7 +30,7 @@ tee-supplicant: $(TEES_FILE)
 
 $(TEES_FILE): $(TEES_OBJS)
 	@echo "  LD      $@"
-	$(VPREFIX)$(CC) $(TEES_LDFLAGS) -o $@ $+
+	$(VPREFIX)$(CC) -o $@ $+ $(TEES_LDFLAGS)
 	@echo ""
 
 $(TEES_OBJ_DIR)/%.o: $(TEES_SRC_DIR)/%.c


### PR DESCRIPTION
The following patches fix build issues I found when building with:

```
$ arm-linux-gnueabihf-gcc --version
arm-linux-gnueabihf-gcc (Ubuntu/Linaro 4.8.2-16ubuntu4) 4.8.2
Copyright (C) 2013 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
