### PR TITLE
Cross Compiler set change

### DIFF
--- a/flags.mk
+++ b/flags.mk
@@ -3,7 +3,7 @@
 #########################################################################
 
 CROSS_COMPILE   ?= arm-linux-gnueabihf-
-CC              := $(CROSS_COMPILE)gcc
+CC              ?= $(CROSS_COMPILE)gcc
 
 CFLAGS          := -Wall -Wbad-function-cast -Wcast-align \
 		   -Werror-implicit-function-declaration -Wextra \


### PR DESCRIPTION
Changed the "CC" default value in the makery.  By setting it to "?=" instead of ":=" will allow the default to be set only if the environment does not have the compiler set.
