### PR TITLE
CC always redefined

### DIFF
--- a/flags.mk
+++ b/flags.mk
@@ -3,7 +3,7 @@
 #########################################################################
 
 CROSS_COMPILE   ?= arm-linux-gnueabihf-
-CC              ?= $(CROSS_COMPILE)gcc
+CC              := $(CROSS_COMPILE)gcc
 
 CFLAGS          := -Wall -Wbad-function-cast -Wcast-align \
 		   -Werror-implicit-function-declaration -Wextra \


### PR DESCRIPTION
Without setting CC from you shell, when calling make, it was
defaulted to CC=cc instead of picking up $(CROSS_COMPILE)gcc

Current patch uses an extra makefile variable
    BASIC_CC ?= gcc
so that CC is always defined as
    CC := $(CROSS_COMPILE)$(BASIC_CC)

Signed-off-by: Pascal Brand pascal.brand@st.com
