### PR TITLE
Travis: use default arm-linux-gnueabihf- compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 # One may have a look at http://docs.travis-ci.com/user/installing-dependencies/
 
+language: c
+
 notifications:
   - email: true
 
-# Installation of ia32 libs, required by the compiler
+# Install the cross-compiler
 before_install:
   - sudo apt-get update -qq
-  - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch; fi
-
-# Download the arm compiler to use
-before_script:
-  - wget http://releases.linaro.org/14.05/components/toolchain/binaries/gcc-linaro-arm-linux-gnueabihf-4.9-2014.05_linux.tar.xz
-  - tar xvf gcc-linaro-arm-linux-gnueabihf-4.9-2014.05_linux.tar.xz
-  - export PATH=$PATH:$PWD/gcc-linaro-arm-linux-gnueabihf-4.9-2014.05_linux/bin
+  - sudo apt-get install -y gcc-arm-linux-gnueabihf
+  - arm-linux-gnueabihf-gcc --version
 
 # Several compilation options are checked
 script:


### PR DESCRIPTION
The download of the Linaro compiler as well as the installation of
its dependencies (including some 32-bit libraries) is replaced by
the installation of the default gcc-arm-linux-gnueabihf package.

This speeds up the build significantly.

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
