### PR TITLE
Add TEEC_ErrorOrigin typedef

### DIFF
--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -232,6 +232,7 @@
 #define TEEC_PARAM_TYPE_GET(p, i) (((p) >> (i * 4)) & 0xF)
 
 typedef uint32_t TEEC_Result;
+typedef uint32_t TEEC_ErrorOrigin;
 
 /**
  * struct TEEC_Context - Represents a connection between a client application


### PR DESCRIPTION
Add TEEC_ErrorOrigin typedef, which is referred to in the TEEC_ORIGIN_XX comments

Greetings!
My name is Eric Montellese, and I'm working on integrating OPTEE for an ST project.  Noticed this small omission.

Thanks!
Eric