### PR TITLE
Restructure data struct to support 32-bit CA running with 64-bit linu…

### DIFF
--- a/libteec/include/linux/tee_ioc.h
+++ b/libteec/include/linux/tee_ioc.h
@@ -47,25 +47,45 @@
  * with the user space.
  */
 struct tee_cmd_io {
-	uint32_t err;
+	TEEC_Result err;
 	uint32_t origin;
 	uint32_t cmd;
-	TEEC_UUID __user *uuid;
-	void __user *data;
-	uint32_t data_size;
-	TEEC_Operation __user *op;
 	int fd_sess;
+	/*
+	 * Here fd_sess is 32-bit variable. Since TEEC_Result also is defined as
+	 * "uint32_t", this structure is aligned.
+	 */
+	union {
+		TEEC_UUID __user *uuid;
+		uint64_t padding_uuid;
+	};
+	union {
+		void __user *data;
+		uint64_t padding_data;
+	};
+	union {
+		TEEC_Operation __user *op;
+		uint64_t padding_op;
+	};
+	uint32_t data_size;
+	int32_t reserved;
 };
 
 struct tee_shm_io {
-	void __user *buffer;
-	size_t size;
-	uint32_t flags;
 	union {
-		int fd_shm;
-		void *ptr;
+		void __user *buffer;
+		uint64_t padding_buf;
 	};
-	uint8_t registered;
+	uint32_t size;
+	uint32_t flags;
+	/*
+	 * Here fd_shm is 32-bit. To be compliant with the convention of file
+	 * descriptor definition, fd_shm is defined as "int" type other
+	 * than "int32_t". Even though using "int32_t" is more obvious to
+	 * indicate that we intend to keep this structure aligned.
+	 */
+	int fd_shm;
+	uint32_t registered;
 };
 
 #define TEE_OPEN_SESSION_IOC		_IOWR('t', 161, struct tee_cmd_io)

--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -76,6 +76,8 @@ static void teec_mutex_unlock(pthread_mutex_t *mu)
 
 static void teec_resetTeeCmd(struct tee_cmd_io *cmd)
 {
+	memset((void *)cmd, 0, sizeof(struct tee_cmd_io));
+
 	cmd->fd_sess	= -1;
 	cmd->cmd	= 0;
 	cmd->uuid	= NULL;
@@ -121,6 +123,8 @@ TEEC_Result TEEC_InitializeContext(const char *name, TEEC_Context *context)
 	if (context->fd == -1)
 		return TEEC_ERROR_ITEM_NOT_FOUND;
 
+	pthread_mutex_init(&mutex, NULL);
+
 	OUTMSG("");
 	return TEEC_SUCCESS;
 }
@@ -142,6 +146,7 @@ void TEEC_FinalizeContext(TEEC_Context *context)
 TEEC_Result TEEC_AllocateSharedMemory(TEEC_Context *context,
 				      TEEC_SharedMemory *shared_memory)
 {
+	struct tee_shm_io shm;
 	size_t size;
 	uint32_t flags;
 
@@ -154,12 +159,23 @@ TEEC_Result TEEC_AllocateSharedMemory(TEEC_Context *context,
 	shared_memory->size = size;
 	shared_memory->flags = flags;
 
-	if (ioctl(context->fd, TEE_ALLOC_SHM_IOC, shared_memory) != 0) {
+	memset((void *)&shm, 0, sizeof(shm));
+	shm.buffer = NULL;
+	shm.size   = size;
+	shm.registered = 0;
+	shm.fd_shm = 0;
+	shm.flags = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT;
+	if (ioctl(context->fd, TEE_ALLOC_SHM_IOC, &shm) != 0) {
 		EMSG("Ioctl(TEE_ALLOC_SHM_IOC) failed! (%s)\n",
 		     strerror(errno));
 		return TEEC_ERROR_OUT_OF_MEMORY;
 	}
-	DMSG("fd %d size %zd flags %08x", shared_memory->d.fd, shared_memory->size, shared_memory->flags);
+
+	DMSG("fd %d size %d flags %08x", shared_memory->d.fd,
+		(int)shared_memory->size, shared_memory->flags);
+
+	shared_memory->size = size;
+	shared_memory->d.fd = shm.fd_shm;
 
 	/*
 	 * Map memory to current user space process.

--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -270,6 +270,14 @@ typedef struct {
 } TEEC_UUID;
 
 /**
+ * In terms of compatible kernel, the data struct shared by client application
+ * and TEE driver should be restructrued in "compatible" rules. To keep GP's
+ * standard in compatibility mode, the anonymous padding members are filled
+ * in the struct definition below.
+ */
+
+
+/**
  * struct TEEC_SharedMemory - Memory to transfer data between a client
  * application and trusted code.
  *
@@ -286,8 +294,14 @@ typedef struct {
  * is responsible to populate the buffer pointer.
  */
 typedef struct {
-	void *buffer;
-	size_t size;
+	union {
+		void *buffer;
+		uint64_t padding_ptr;
+	};
+	union {
+		size_t size;
+		uint64_t padding_sz;
+	};
 	uint32_t flags;
 	/*
 	 * Implementation-Defined, must match what the kernel driver have
@@ -295,11 +309,13 @@ typedef struct {
 	 * Identifier can store a handle (int) or a structure pointer (void *).
 	 * Define this union to match case where sizeof(int)!=sizeof(void *).
 	 */
+	uint32_t reserved;
 	union {
 		int fd;
 		void *ptr;
+		uint64_t padding_d;
 	} d;
-	uint8_t registered;
+	uint64_t registered;
 } TEEC_SharedMemory;
 
 /**
@@ -315,8 +331,14 @@ typedef struct {
  * operation to be called.
  */
 typedef struct {
-	void *buffer;
-	size_t size;
+	union {
+		void *buffer;
+		uint64_t padding_ptr;
+	};
+	union {
+		size_t size;
+		uint64_t padding_sz;
+	};
 } TEEC_TempMemoryReference;
 
 /**
@@ -335,9 +357,18 @@ typedef struct {
  *
  */
 typedef struct {
-	TEEC_SharedMemory *parent;
-	size_t size;
-	size_t offset;
+	union {
+		TEEC_SharedMemory *parent;
+		uint64_t padding_ptr;
+	};
+	union {
+		size_t size;
+		uint64_t padding_sz;
+	};
+	union {
+		size_t offset;
+		uint64_t padding_off;
+	};
 } TEEC_RegisteredMemoryReference;
 
 /**
@@ -407,9 +438,12 @@ typedef struct {
 	uint32_t paramTypes;
 	TEEC_Parameter params[TEEC_CONFIG_PAYLOAD_REF_COUNT];
 	/* Implementation-Defined */
-	TEEC_Session *session;
+	union {
+		TEEC_Session *session;
+		uint64_t padding_ptr;
+	};
 	TEEC_SharedMemory memRefs[TEEC_CONFIG_PAYLOAD_REF_COUNT];
-	uint32_t flags;
+	uint64_t flags;
 } TEEC_Operation;
 
 /**


### PR DESCRIPTION
…x kernel

The data struct is modified for aligning with the changes in OPTEE
driver.

This commit includes:
- Add padding member in unaligned struct
- Call pthread_mutex_init to initialize mutex
- Add compile option to build static TEE library and supplicant

Signed-off-by: Aijun Sun <aijun.sun@linaro.org>