### PR TITLE
Android.mk: s/tee_supplicant/tee-supplicant/

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -55,6 +55,6 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/public \
 		$(LOCAL_PATH)/tee-supplicant/src
 
 LOCAL_SHARED_LIBRARIES := libteec
-LOCAL_MODULE := tee_supplicant
+LOCAL_MODULE := tee-supplicant
 LOCAL_MODULE_TAGS := optional
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
Fixes the name of the TEE supplicant binary in Android builds. Indeed,
the current driver expects current->comm to be "tee-supplicant", any
other name results in the process failing to start.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>