### PR TITLE
Make CC configurable via the environment

### DIFF
--- a/flags.mk
+++ b/flags.mk
@@ -3,7 +3,7 @@
 #########################################################################
 
 CROSS_COMPILE   ?= arm-linux-gnueabihf-
-CC              := $(CROSS_COMPILE)gcc
+CC              ?= $(CROSS_COMPILE)gcc
 
 CFLAGS          := -Wall -Wbad-function-cast -Wcast-align \
 		   -Werror-implicit-function-declaration -Wextra \


### PR DESCRIPTION
Trying to build optee_client with yocto. Required to
override CC with CC set by yocto environment.

Signed-off-by: Sumit Garg <b49020@freescale.com>