### PR TITLE
Fixes incorrectly built library and binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ all: build install
 
 build-libteec:
 	@echo "Building libteec.so"
-	@$(MAKE) --directory=libteec --no-print-directory
+	@$(MAKE) --directory=libteec --no-print-directory --no-builtin-variables
 
 build-tee-supplicant: build-libteec
 	@echo "Building tee-supplicant"
-	$(MAKE) --directory=tee-supplicant  --no-print-directory
+	$(MAKE) --directory=tee-supplicant  --no-print-directory --no-builtin-variables
 
 build: build-libteec build-tee-supplicant
 


### PR DESCRIPTION
The previous patch made it possible to override the CC variable.
However, when you don't assign anything at all, there will still be a
value assigned by the implicit variables and hence both libtee.so and
tee-supplicant will be built using the host compiler instead of the
(ARM) cross compiler and as a result of that other builds like xtest etc
will fail. We fix this by adding the argument "--no-builtin-variables"
when calling the individual makefile(s).

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>