### PR TITLE
Try loading TAs from another writable path

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -32,6 +32,12 @@ CFG_TEE_SUPP_LOG_FILE ?= \"/data/teesupp.log\"
 # The location of the client library file.
 CFG_TEE_CLIENT_LOAD_PATH ?= /system/lib
 
+# CFG_TA_TEST_PATH
+# Enable the tee test path.  When enabled, the supplicant will try
+# loading from a debug path before the regular path.  This allows test
+# such as 1008.5 that test loading of corrupt TAs.
+CFG_TA_TEST_PATH ?= 1
+
 # Default out dir.
 # Must be a relative path with respect to the op-tee-client root directory
 O               ?= out

--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -1,4 +1,5 @@
 include ../flags.mk
+include ../config.mk
 
 OUT_DIR		?= ${CURDIR}/../$(O)/tee-supplicant
 
@@ -35,6 +36,9 @@ TEES_CFLAGS	:= $(addprefix -I, $(TEES_INCLUDES)) $(CFLAGS) \
 		   -DBINARY_PREFIX=\"TEES\"
 ifeq ($(RPMB_EMU),1)
 TEES_CFLAGS	+= -DRPMB_EMU=1
+endif
+ifeq ($(CFG_TA_TEST_PATH),1)
+TEES_CFLAGS	+= -DCFG_TA_TEST_PATH=1
 endif
 TEES_FILE	:= $(OUT_DIR)/$(PACKAGE_NAME)
 TEES_LDFLAGS    := -L$(OUT_DIR)/../libteec -lteec

--- a/tee-supplicant/tee_supplicant_android.mk
+++ b/tee-supplicant/tee_supplicant_android.mk
@@ -10,6 +10,10 @@ LOCAL_CFLAGS += -DDEBUGLEVEL_$(CFG_TEE_SUPP_LOG_LEVEL) \
                 -DBINARY_PREFIX=\"TEES\" \
                 -DTEEC_LOAD_PATH=\"$(CFG_TEE_CLIENT_LOAD_PATH)\" \
 
+ifeq ($(CFG_TA_TEST_PATH),1)
+LOCAL_CFLAGS += -DCFG_TA_TEST_PATH=1
+endif
+
 LOCAL_SRC_FILES += src/handle.c \
                    src/tee_supp_fs.c \
                    src/tee_supplicant.c \


### PR DESCRIPTION
To allow testing of corrupt TA loading on systems where the TA
directory is read-only, try loading TAs first from an alternate
`TEEC_TEST_LOAD_PATH` before the regular path.  This allows the test
to override the TA with one for testing purposes.

Although useful for testing, this should not be enabled for a
production system, since it facilitates replacing a TA with a corrupt
image.

Signed-off-by: David Brown <david.brown@linaro.org>