### PR TITLE
Remove the connection_method limit

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -467,13 +467,6 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 		goto out;
 	}
 
-	if (connection_method != TEEC_LOGIN_PUBLIC) {
-		eorig = TEEC_ORIGIN_API;
-		res = TEEC_ERROR_NOT_SUPPORTED;
-		goto out;
-	}
-
-
 	buf_data.buf_ptr = (uintptr_t)buf;
 	buf_data.buf_len = sizeof(buf);
 
@@ -482,7 +475,7 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 	params = (struct tee_ioctl_param *)(arg + 1);
 
 	memcpy(arg->uuid, destination, sizeof(TEEC_UUID));
-	arg->clnt_login = TEEC_LOGIN_PUBLIC;
+	arg->clnt_login = connection_method;
 
 	res = teec_pre_process_operation(ctx, operation, params, shm);
 	if (res != TEEC_SUCCESS) {

--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -200,18 +200,24 @@
  * Session login methods, for use in TEEC_OpenSession() as parameter
  * connectionMethod. Type is uint32_t.
  *
- * TEEC_LOGIN_PUBLIC       No login data is provided.
- * TEEC_LOGIN_USER         Login data about the user running the Client
- *                         Application process is provided.
- * TEEC_LOGIN_GROUP        Login data about the group running the Client
- *                         Application process is provided.
- * TEEC_LOGIN_APPLICATION  Login data about the running Client Application
- *                         itself is provided.
+ * TEEC_LOGIN_PUBLIC    	 No login data is provided.
+ * TEEC_LOGIN_USER         	Login data about the user running the Client
+ *                         	Application process is provided.
+ * TEEC_LOGIN_GROUP        	Login data about the group running the Client
+ *                         	Application process is provided.
+ * TEEC_LOGIN_APPLICATION  	Login data about the running Client Application
+ *                         	itself is provided.
+ * TEEC_LOGIN_USER_APPLICATION  Login data about the user and the running
+ *                          	Client Application itself is provided.
+ * TEEC_LOGIN_GROUP_APPLICATION Login data about the group and the running
+ *                          	Client Application itself is provided.
  */
 #define TEEC_LOGIN_PUBLIC       0x00000000
 #define TEEC_LOGIN_USER         0x00000001
 #define TEEC_LOGIN_GROUP        0x00000002
 #define TEEC_LOGIN_APPLICATION  0x00000004
+#define TEEC_LOGIN_USER_APPLICATION  0x00000005
+#define TEEC_LOGIN_GROUP_APPLICATION  0x00000006
 
 /**
  * Encode the paramTypes according to the supplied types.


### PR DESCRIPTION
Since we have to add support for login method other than TEE_LOGIN_PUBLIC
in the future, remove the limit now.

Signed-off-by: Zeng Tao <prime.zeng@huawei.com>