### PR TITLE
Use "make V=1" for verbose build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,8 @@ include ./config.mk
 # Set Internal Variables						#
 # May be modified to match your setup                                   #
 #########################################################################
-BUILD_VERBOSE	?= 0
-VPREFIX		?= @
-ifeq ($(BUILD_VERBOSE),1)
-VPREFIX:=
+ifneq ($(V),1)
+VPREFIX := @
 endif
 export VPREFIX
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ downloading and unpacking the compiler. Then export the PATH to the bin folder.
 To be able to see the full command when building you could build using following
 flag:
 
-`$ make BUILD_VERBOSE=1`
+`$ make V=1`
 
 ## Coding standards
 In this project we are trying to adhere to the same coding convention as used in


### PR DESCRIPTION
Replace 'VERBOSE_BUILD' with 'V' for simplicity and consistency with
other projects.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>