### PR TITLE
[RFC] libteec: add secure memref parameter type (SWG-186)

### DIFF
--- a/libteec/include/linux/tee.h
+++ b/libteec/include/linux/tee.h
@@ -144,6 +144,7 @@ struct tee_ioctl_buf_data {
  * These defines shared memory reference parameters (struct
  * tee_ioctl_param_memref)
  */
+#define TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_SECURE	4
 #define TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT	5
 #define TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT	6
 #define TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INOUT	7	/* input and output */

--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -76,6 +76,11 @@
  *                             behaviors of TEEC_MEMREF_TEMP_INPUT and
  *                             TEEC_MEMREF_TEMP_OUTPUT apply.
  *
+ * TEEC_MEMREF_SECURE          Memref relates to a secure buffer. Cpu must
+ *                             not attempt to access to the buffer, not even
+ *                             map it. Private field 'id' of structure
+ *                             TEEC_SharedMemory stores a dmabuf file handle.
+ *
  * TEEC_MEMREF_WHOLE           The Parameter is a Registered Memory Reference
  *                             that refers to the entirety of its parent Shared
  *                             Memory block. The parameter structure is a
@@ -103,6 +108,7 @@
 #define TEEC_VALUE_INPUT            0x00000001
 #define TEEC_VALUE_OUTPUT           0x00000002
 #define TEEC_VALUE_INOUT            0x00000003
+#define TEEC_MEMREF_SECURE          0x00000004
 #define TEEC_MEMREF_TEMP_INPUT      0x00000005
 #define TEEC_MEMREF_TEMP_OUTPUT     0x00000006
 #define TEEC_MEMREF_TEMP_INOUT      0x00000007
@@ -121,9 +127,12 @@
  *                  application to the Trusted Application.
  * TEEC_MEM_OUTPUT  The Shared Memory can carry data from the Trusted
  *                  Application to the client application.
+ * TEEC_MEM_SECURE  The referenced memory is a secure buffer.
+ *                  TEE connection is not expected to access memory.
  */
-#define TEEC_MEM_INPUT   0x00000001
-#define TEEC_MEM_OUTPUT  0x00000002
+#define TEEC_MEM_INPUT         0x00000001
+#define TEEC_MEM_OUTPUT        0x00000002
+#define TEEC_MEM_SECURE        0x00000004
 
 /**
  * Return values. Type is TEEC_Result


### PR DESCRIPTION
Introduce a new TEE parameter type identifier: TEEC_MEMREF_SECURE.

TEE Client API provides this type identifier for buffer that client shall
not attempt to access (secure memory buffer) but that are used as
input or output memory buffers.

As for legacy TEEC_MEMREF_xxx parameters, TEEC_SharedMemory structure
holds the memory reference. In case of "secure" memrefs:
- field 'id' provides the dma_buf file handle that refers the buffer
- field 'flag' must set the bit TEEC_MEM_SECURE

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

This PR requires few changes in the [optee_os PR1052](https://github.com/OP-TEE/optee_os/pull/1052) and tee/optee linux driver [linux/swg PR23](https://github.com/linaro-swg/linux/pull/23).