### PR TITLE
new API to register shared memory from a file descriptor (SWG-186)

### DIFF
--- a/libteec/include/linux/tee.h
+++ b/libteec/include/linux/tee.h
@@ -38,7 +38,6 @@
  * data passed back and forth using TEE_IOC_CMD.
  */
 
-
 /* Helpers to make the ioctl defines */
 #define TEE_IOC_MAGIC	0xa4
 #define TEE_IOC_BASE	0
@@ -76,6 +75,7 @@ struct tee_ioctl_version_data {
 	__u32 impl_caps;
 	__u32 gen_caps;
 };
+
 /**
  * TEE_IOC_VERSION - query version of TEE
  *
@@ -100,6 +100,7 @@ struct tee_ioctl_shm_alloc_data {
 	__u32 flags;
 	__s32 id;
 };
+
 /**
  * TEE_IOC_SHM_ALLOC - allocate shared memory
  *
@@ -156,7 +157,6 @@ struct tee_ioctl_buf_data {
 	__u64 buf_len;
 };
 
-
 /*
  * Attributes for struct tee_ioctl_param, selects field in the union
  */
@@ -184,7 +184,7 @@ struct tee_ioctl_buf_data {
 
 /*
  * Matches TEEC_LOGIN_* in GP TEE Client API
- * Is only defined for GP compliant TEEs
+ * Are only defined for GP compliant TEEs
  */
 #define TEE_IOCTL_LOGIN_PUBLIC			0
 #define TEE_IOCTL_LOGIN_USER			1
@@ -216,6 +216,8 @@ struct tee_ioctl_param_memref {
  * @a: first value
  * @b: second value
  * @c: third value
+ *
+ * Value parameters are passed unchecked to the destination
  */
 struct tee_ioctl_param_value {
 	__u64 a;
@@ -248,7 +250,7 @@ struct tee_ioctl_param {
  * struct tee_ioctl_open_session_arg - Open session argument
  * @uuid:	[in] UUID of the Trusted Application
  * @clnt_uuid:	[in] UUID of client
- * @clnt_login:	[in] Login class of client, TEE_LOGIN_* above
+ * @clnt_login:	[in] Login class of client, TEE_IOCTL_LOGIN_* above
  * @cancel_id:	[in] Cancellation id, a unique value to identify this request
  * @session:	[out] Session id
  * @ret:	[out] return value
@@ -287,7 +289,8 @@ struct tee_ioctl_open_session_arg {
 				     struct tee_ioctl_buf_data)
 
 /**
- * struct tee_ioctl_invoke_func_arg - Invokes a function in a Trusted Application
+ * struct tee_ioctl_invoke_func_arg - Invokes a function in a Trusted
+ * Application
  * @func:	[in] Trusted Application function, specific to the TA
  * @session:	[in] Session id
  * @cancel_id:	[in] Cancellation id, a unique value to identify this request
@@ -332,6 +335,7 @@ struct tee_ioctl_cancel_arg {
 	__u32 cancel_id;
 	__u32 session;
 };
+
 /**
  * TEE_IOC_CANCEL - Cancels an open session or invoke
  */
@@ -345,6 +349,7 @@ struct tee_ioctl_cancel_arg {
 struct tee_ioctl_close_session_arg {
 	__u32 session;
 };
+
 /**
  * TEE_IOC_CLOSE_SESSION - Closes a session
  */
@@ -374,6 +379,7 @@ struct tee_iocl_supp_recv_arg {
 	 * struct tee_ioctl_param params[num_params];
 	 */
 } __aligned(8);
+
 /**
  * TEE_IOC_SUPPL_RECV - Receive a request for a supplicant function
  *
@@ -382,7 +388,6 @@ struct tee_iocl_supp_recv_arg {
  */
 #define TEE_IOC_SUPPL_RECV	_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 6, \
 				     struct tee_ioctl_buf_data)
-
 
 /**
  * struct tee_iocl_supp_send_arg - Send a response to a received request
@@ -411,7 +416,6 @@ struct tee_iocl_supp_send_arg {
  */
 #define TEE_IOC_SUPPL_SEND	_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 7, \
 				     struct tee_ioctl_buf_data)
-
 
 /*
  * Five syscalls are used when communicating with the TEE driver.

--- a/libteec/include/linux/tee.h
+++ b/libteec/include/linux/tee.h
@@ -115,6 +115,35 @@ struct tee_ioctl_shm_alloc_data {
 				     struct tee_ioctl_shm_alloc_data)
 
 /**
+ * struct tee_ioctl_shm_register_fd_data - Shared memory registering argument
+ * @fd:		[in] file descriptor identifying the shared memory
+ * @size:	[out] Size of shared memory to allocate
+ * @flags:	[in] Flags to/from allocation.
+ * @id:		[out] Identifier of the shared memory
+ *
+ * The flags field should currently be zero as input. Updated by the call
+ * with actual flags as defined by TEE_IOCTL_SHM_* above.
+ * This structure is used as argument for TEE_IOC_SHM_ALLOC below.
+ */
+struct tee_ioctl_shm_register_fd_data {
+	__s64 fd;
+	__u64 size;
+	__u32 flags;
+	__s32 id;
+} __aligned(8);
+
+/**
+ * TEE_IOC_SHM_REGISTER_FD - register a shared memory from a file descriptor
+ *
+ * Returns a file descriptor on success or < 0 on failure
+ *
+ * The returned file descriptor refers to the shared memory object in kernel
+ * land. The shared memory is freed when the descriptor is closed.
+ */
+#define TEE_IOC_SHM_REGISTER_FD	_IOWR(TEE_IOC_MAGIC, TEE_IOC_BASE + 8, \
+				     struct tee_ioctl_shm_register_fd_data)
+
+/**
  * struct tee_ioctl_buf_data - Variable sized buffer
  * @buf_ptr:	[in] A __user pointer to a buffer
  * @buf_len:	[in] Length of the buffer above

--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -287,6 +287,7 @@ typedef struct {
 	int id;
 	size_t alloced_size;
 	void *shadow_buffer;
+	int registered_fd;
 } TEEC_SharedMemory;
 
 /**

--- a/public/tee_client_api_extensions.h
+++ b/public/tee_client_api_extensions.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TEE_CLIENT_API_EXTENSIONS_H
+#define TEE_CLIENT_API_EXTENSIONS_H
+
+#include <tee_client_api.h>
+
+/**
+ * TEEC_RegisterMemoryFileDescriptor() - Register a block of existing memory as
+ * a shared block within the scope of the specified context.
+ *
+ * @param context    The initialized TEE context structure in which scope to
+ *                   open the session.
+ * @param sharedMem  pointer to the shared memory structure to register.
+ * @param fd         file descriptor of the target memory.
+ *
+ * @return TEEC_SUCCESS              The registration was successful.
+ * @return TEEC_ERROR_OUT_OF_MEMORY  Memory exhaustion.
+ * @return TEEC_Result               Something failed.
+ */
+TEEC_Result TEEC_RegisterSharedMemoryFileDescriptor(TEEC_Context *context,
+						    TEEC_SharedMemory *sharedMem,
+						    int fd);
+
+#endif /* TEE_CLIENT_API_EXTENSIONS_H */


### PR DESCRIPTION
This is a proposal for implementing the ability for a TA to safely handle memory buffer arguments related to secure buffers. See SWG-186.

This proposal defines a new API in the TEE Client API: `TEEC_RegisterSharedMemoryFileDescriptor()`.

The libteec requests a ioctl to the TEE driver to register the buffer and get a new file descriptor for the TEE shared memory structure. API will simply close this file descriptor to release the shared memory resource.

This PR is related to changes in the TEE linux driver: https://github.com/linaro-swg/linux/pull/26.
