### PR TITLE
tee_api: check for session->ctx before dereferencing it

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -510,7 +510,7 @@ void TEEC_CloseSession(TEEC_Session *session)
 {
 	struct tee_ioctl_close_session_arg arg;
 
-	if (!session)
+	if (!session || !session->ctx)
 		return;
 
 	arg.session = session->session_id;
@@ -533,7 +533,7 @@ TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
 	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
 	int rc;
 
-	if (!session) {
+	if (!session || !session->ctx) {
 		eorig = TEEC_ORIGIN_API;
 		res = TEEC_ERROR_BAD_PARAMETERS;
 		goto out;
@@ -593,7 +593,7 @@ void TEEC_RequestCancellation(TEEC_Operation *operation)
 	session = operation->session;
 	teec_mutex_unlock(&teec_mutex);
 
-	if (!session)
+	if (!session || !session->ctx)
 		return;
 
 	arg.session = session->session_id;


### PR DESCRIPTION
We need to check if session->ctx is valid pointer befor dereferncing it.
Otherways it will lead to segfalut which is not desired behaviour for
library users.
This fill fix issue with segfaulting xtest when TEEC_OpenSession fails.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>