### PR TITLE
Allow O to be any kind of path (absolute, relative, with ~)

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -38,10 +38,12 @@ CFG_TEE_CLIENT_LOAD_PATH ?= /system/lib
 # such as 1008.5 that test loading of corrupt TAs.
 CFG_TA_TEST_PATH ?= 1
 
-# Default out dir.
-# Must be a relative path with respect to the op-tee-client root directory
+# Default output directory.
+# May be absolute, or relative to the optee_client source directory.
 O               ?= out
-export O
+
+# To be used instead of $(O) in sub-directories
+OO := $(if $(filter /%,$(O)),$(O),$(CURDIR)/../$(O))
 
 #########################################################################
 # Private Values                                                        #

--- a/libsqlfs/Makefile
+++ b/libsqlfs/Makefile
@@ -4,9 +4,9 @@
 # and/or linking it statically! See COPYING section 6.
 
 include ../flags.mk
+include ../config.mk
 
-O ?= out
-OUT_DIR	?= ${CURDIR}/../$(O)/libsqlfs
+OUT_DIR := $(OO)/libsqlfs
 
 .PHONY: all libsqlfs clean
 
@@ -39,10 +39,11 @@ SQLFS_CFLAGS := $(addprefix -I, $(SQLFS_INCLUDES)) \
 	-Wno-missing-format-attribute
 
 SQLFS_LFLAGS := -lpthread
-SQLFS_LIBS := $(CURDIR)/../$(O)/libsqlite3/libsqlite3.a
+SQLFS_LIBS := $(OUT_DIR)/../libsqlite3/libsqlite3.a
 SQLFS_LIBRARY := $(OUT_DIR)/$(LIB_MAJ_MIN)
 
 libsqlfs: $(SQLFS_LIBRARY)
+	$(VPREFIX)mkdir -p $(OUT_DIR)
 	$(VPREFIX)ln -sf $(SQLFS_LIBRARY) $(OUT_DIR)/$(LIB_MAJOR)
 	$(VPREFIX)ln -sf $(OUT_DIR)/$(LIB_MAJOR) $(OUT_DIR)/$(LIB_NAME)
 

--- a/libsqlite3/Makefile
+++ b/libsqlite3/Makefile
@@ -1,7 +1,7 @@
 include ../flags.mk
+include ../config.mk
 
-O ?= out
-OUT_DIR	?= ${CURDIR}/../$(O)/libsqlite3
+OUT_DIR	:= $(OO)/libsqlite3
 
 .PHONY: all libsqlite3 clean
 

--- a/libteec/Makefile
+++ b/libteec/Makefile
@@ -1,6 +1,7 @@
 include ../flags.mk
+include ../config.mk
 
-OUT_DIR		?= ${CURDIR}/../$(O)/libteec
+OUT_DIR := $(OO)/libteec
 
 .PHONY: all libteec clean
 

--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -1,7 +1,7 @@
 include ../flags.mk
 include ../config.mk
 
-OUT_DIR		?= ${CURDIR}/../$(O)/tee-supplicant
+OUT_DIR := $(OO)/tee-supplicant
 
 # Emulate RPMB ioctl's
 RPMB_EMU	:= 1


### PR DESCRIPTION
Tested with:
  $ export CFG_WITH_SQLFS=y
  $ make
  $ make O=build
  $ make O=/tmp/build
  $ make O=~/build

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Suggested-by: Zeng Tao <prime.zeng@hisilicon.com>