### PR TITLE
tee-supplicant: add missing unistd.h to tee_fs.h

### DIFF
--- a/tee-supplicant/src/tee_fs.h
+++ b/tee-supplicant/src/tee_fs.h
@@ -28,6 +28,7 @@
 
 #include <fcntl.h>
 #include <stdint.h>
+#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
R_OK, W_OK are defined by uninstd.h. This change ensures
the project can be compiled with Android Bionic