### PR TITLE
tee_client_api: register user memory

### DIFF
--- a/libteec/include/linux/tee.h
+++ b/libteec/include/linux/tee.h
@@ -49,6 +49,7 @@
 #define TEE_MAX_ARG_SIZE	1024
 
 #define TEE_GEN_CAP_GP		(1 << 0)/* GlobalPlatform compliant TEE */
+#define TEE_GEN_CAP_REG_MEM	(1 << 2)/* Supports registering shared memory */
 
 /*
  * TEE Implementation ID
@@ -143,6 +144,36 @@ struct tee_ioctl_shm_register_fd_data {
  */
 #define TEE_IOC_SHM_REGISTER_FD	_IOWR(TEE_IOC_MAGIC, TEE_IOC_BASE + 8, \
 				     struct tee_ioctl_shm_register_fd_data)
+
+/**
+ * struct tee_ioctl_shm_register_data - Shared memory register argument
+ * @addr:      [in] Start address of shared memory to register
+ * @length:    [in/out] Length of shared memory to register
+ * @flags:     [in/out] Flags to/from registration.
+ * @id:                [out] Identifier of the shared memory
+ *
+ * The flags field should currently be zero as input. Updated by the call
+ * with actual flags as defined by TEE_IOCTL_SHM_* above.
+ * This structure is used as argument for TEE_IOC_SHM_REGISTER below.
+ */
+struct tee_ioctl_shm_register_data {
+	__u64 addr;
+	__u64 length;
+	__u32 flags;
+	__s32 id;
+};
+
+/**
+ * TEE_IOC_SHM_REGISTER - Register shared memory
+ *
+ * Registers shared memory between the user space process and secure OS.
+ *
+ * Returns a file descriptor on success or < 0 on failure
+ *
+ * The shared memory is unregisterred when the descriptor is closed.
+ */
+#define TEE_IOC_SHM_REGISTER   _IOWR(TEE_IOC_MAGIC, TEE_IOC_BASE + 9, \
+				     struct tee_ioctl_shm_register_data)
 
 /**
  * struct tee_ioctl_buf_data - Variable sized buffer

--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -35,6 +35,7 @@ extern "C" {
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 #include <limits.h>
 
 /*
@@ -253,6 +254,7 @@ typedef uint32_t TEEC_Result;
 typedef struct {
 	/* Implementation defined */
 	int fd;
+	bool reg_mem;
 } TEEC_Context;
 
 /**
@@ -294,6 +296,7 @@ typedef struct {
 	size_t alloced_size;
 	void *shadow_buffer;
 	int registered_fd;
+	bool buffer_allocated;
 } TEEC_SharedMemory;
 
 /**


### PR DESCRIPTION
This patch is the userspace part of dynamic shared memory in OP-TEE (refer to https://github.com/OP-TEE/optee_os/pull/1232). This patch is authred by @jenswi-linaro, I just tidied it a bit and rebased on current master.

This patch utilizes new ioctl that allows client application to share any buffer with OP-TEE.