### PR TITLE
ree fs rpc: open with best-effort allowing RO data fs

### DIFF
--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -410,8 +410,15 @@ static TEEC_Result ree_fs_new_open(size_t num_params,
 		return TEEC_ERROR_BAD_PARAMETERS;
 
 	fd = open_wrapper(abs_filename, O_RDWR);
-	if (fd < 0)
-		return TEEC_ERROR_ITEM_NOT_FOUND;
+	if (fd < 0) {
+		/*
+		 * In case the problem is the filesystem is RO, retry with the
+		 * open flags restricted to RO.
+		 */
+		fd = open_wrapper(abs_filename, O_RDONLY);
+		if (fd < 0)
+			return TEEC_ERROR_ITEM_NOT_FOUND;
+	}
 
 	params[2].u.value.a = fd;
 	return TEEC_SUCCESS;


### PR DESCRIPTION
The REE handler for open always uses flags O_RDWR at the moment.

This breaks the possibility to use read-only operations on a
read-only mounted filesystem at /data.

Change it to try to open with O_RDWR, if not possible fall back
to O_RDONLY and only fail if that isn't workable either.

If O_RDONLY isn't enough, then the TA should use another means
to get the fs mounted rw for the duration of his write activity.
He will get failures on the write action if not, but that is
fair enough.

Signed-off-by: Andy Green <andy@warmcat.com>