### PR TITLE
Use the mode also in open_wrapper

### DIFF
--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -379,7 +379,7 @@ static int open_wrapper(const char *fname, int flags)
 	int fd;
 
 	while (true) {
-		fd = open(fname, flags);
+		fd = open(fname, flags, 0600);
 		if (fd >= 0 || errno != EINTR)
 			return fd;
 	}


### PR DESCRIPTION
When source code is built with FORTIFY, it will give an error if you're
doing an open syscall without specifing the mode parameter.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>