### PR TITLE
tee-supplicant: Report OK only for actual loading

### DIFF
--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -279,6 +279,14 @@ static uint32_t load_ta(size_t num_params, struct tee_ioctl_param *params)
 	}
 
 	params[1].u.memref.size = size;
+
+	/*
+	 * If a buffer wasn't provided, just tell which size it should be.
+	 * If it was provided but isn't big enough, report an error.
+	 */
+	if (shm_ta.buffer && size > shm_ta.size)
+		return TEEC_ERROR_SHORT_BUFFER;
+
 	return TEEC_SUCCESS;
 }
 


### PR DESCRIPTION
I know that optee_os' strategy is to first pass all-zeroed parameters so that it gets back the size to allocate.
But let's say that for some reason the allocation is invalid, that it to say it was successful, but not good enough for TA copying. That can happen for instance if the allocated size is too small, or if the allocation was not done by the supplicant itself (this is what I did, I wrongfully tried to do it by calling `tee_shm_alloc` from kernel space and pass that as buffer).
In that case, during the second call, `try_load_secure_module` will return `TA_BINARY_FOUND`, letting the caller believe that the copy worked as expected.

I don't know if this is the right fix, and it probably has consequences on the linux driver and/or on optee_os, but this is a start!