### PR TITLE
Android.mk: fix CFG_TEE_CLIENT_LOG_FILE checking

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -17,7 +17,7 @@ optee_CFLAGS = $(CFLAGS)
 include $(CLEAR_VARS)
 LOCAL_CFLAGS += $(optee_CFLAGS)
 
-ifeq ($(CFG_TEE_CLIENT_LOG_FILE), true)
+ifneq ($(CFG_TEE_CLIENT_LOG_FILE),)
 LOCAL_CFLAGS += -DTEEC_LOG_FILE=$(CFG_TEE_CLIENT_LOG_FILE)
 endif
 


### PR DESCRIPTION
CFG_TEE_CLIENT_LOG_FILE variable contains the client library log file
path. The correct way to check if the variable is not empty is using
ifneq operator.

Signed-off-by: Ruslan Piasetskyi <ruslan.piasetskyi@gmail.com>