### PR TITLE
Fix incorrect share memory size

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -340,7 +340,7 @@ static void teec_post_process_whole(TEEC_RegisteredMemoryReference *memref,
 		 * the shadow buffer into the real buffer now that we've
 		 * returned from secure world.
 		 */
-		if (shm->shadow_buffer && param->u.memref.size <= memref->size)
+		if (shm->shadow_buffer && param->u.memref.size <= shm->size)
 			memcpy(shm->buffer, shm->shadow_buffer,
 			       param->u.memref.size);
 


### PR DESCRIPTION
Accroding to TEE Client API Spec section 4.3.8 TEEC_RegisteredMemoryReference,
when handling a TEEC_RegisteredMemoryReference parameter of TEEC_MEMREF_WHOLE
type, the memory region size should read from its parent TEEC_SharedMemory
structure instead of the size described in TEEC_RegisteredMemoryReference
structure.

Signed-off-by: James Kung <kong1191@gmail.com>