### PR TITLE
client api: fix ULONG_MAX dependency

### DIFF
--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -31,6 +31,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <limits.h>
 
 /*
  * Defines the number of available memory references in an open session or


### PR DESCRIPTION
ULONG_MAX depends on limits.h.

Fixes: 9faeb1b6b023 ("tee_client_api: Correct max shared memory size define")
