### PR TITLE
supplicant: clean duplicated command IDs

### DIFF
--- a/tee-supplicant/src/optee_msg_supplicant.h
+++ b/tee-supplicant/src/optee_msg_supplicant.h
@@ -43,13 +43,6 @@
  */
 #define OPTEE_MSG_RPC_CMD_FS		2
 
-/* Was OPTEE_MSG_RPC_CMD_SQL_FS, which isn't supported any longer */
-#define OPTEE_MSG_RPC_CMD_SQL_FS_RESERVED	8
-
-/*
- * Values 3-7 are reserved in optee_msg.h for use by the kernel driver
- */
-
 /*
  * Define protocol for messages with .cmd == OPTEE_MSG_RPC_CMD_FS and first
  * parameter has the attribute OPTEE_MSG_ATTR_TYPE_VALUE_INPUT.
@@ -158,6 +151,27 @@
 /*
  * End of definitions for messages with .cmd == OPTEE_MSG_RPC_CMD_FS
  */
+
+/*
+ * Command Ids 3, 4 and 5 of OPTEE_MSG_RPC_CMD_xxx macros are reserved for use
+ * by the kernel driver.
+ */
+
+/*
+ * Shared memory allocation
+ */
+#define OPTEE_MSG_RPC_CMD_SHM_ALLOC	6
+#define OPTEE_MSG_RPC_CMD_SHM_FREE	7
+
+/*
+ * Was OPTEE_MSG_RPC_CMD_SQL_FS, which isn't supported any longer
+ */
+#define OPTEE_MSG_RPC_CMD_SQL_FS_RESERVED	8
+
+/*
+ * GPROF support management commands
+ */
+#define OPTEE_MSG_RPC_CMD_GPROF		9
 
 /*
  * Socket commands

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -65,13 +65,6 @@
 #define RPC_BUF_SIZE	(sizeof(struct tee_iocl_supp_send_arg) + \
 			 RPC_NUM_PARAMS * sizeof(struct tee_ioctl_param))
 
-#define RPC_CMD_LOAD_TA		0
-#define RPC_CMD_RPMB		1
-#define RPC_CMD_FS		2
-#define RPC_CMD_SHM_ALLOC	6
-#define RPC_CMD_SHM_FREE	7
-#define RPC_CMD_GPROF		9
-
 union tee_rpc_invoke {
 	uint64_t buf[(RPC_BUF_SIZE - 1) / sizeof(uint64_t) + 1];
 	struct tee_iocl_supp_recv_arg recv;
@@ -525,22 +518,22 @@ static bool process_one_request(struct thread_arg *arg)
 		return false;
 
 	switch (func) {
-	case RPC_CMD_LOAD_TA:
+	case OPTEE_MSG_RPC_CMD_LOAD_TA:
 		ret = load_ta(num_params, params);
 		break;
-	case RPC_CMD_FS:
+	case OPTEE_MSG_RPC_CMD_FS:
 		ret = tee_supp_fs_process(num_params, params);
 		break;
-	case RPC_CMD_RPMB:
+	case OPTEE_MSG_RPC_CMD_RPMB:
 		ret = process_rpmb(num_params, params);
 		break;
-	case RPC_CMD_SHM_ALLOC:
+	case OPTEE_MSG_RPC_CMD_SHM_ALLOC:
 		ret = process_alloc(arg->fd, num_params, params);
 		break;
-	case RPC_CMD_SHM_FREE:
+	case OPTEE_MSG_RPC_CMD_SHM_FREE:
 		ret = process_free(num_params, params);
 		break;
-	case RPC_CMD_GPROF:
+	case OPTEE_MSG_RPC_CMD_GPROF:
 		ret = gprof_process(num_params, params);
 		break;
 	case OPTEE_MSG_RPC_CMD_SOCKET:


### PR DESCRIPTION
Use `OPTEE_MSG_RPC_CMD_xxx` macros from **optee_msg_supplicant.h** rather
than redefining local macros. Add missing macros `OPTEE_MSG_RPC_CMD_SHM_ALLOC/FREE`.