### PR TITLE
libteec: benchmark cleanup

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -25,7 +25,11 @@ LOCAL_CFLAGS += -DDEBUGLEVEL_$(CFG_TEE_CLIENT_LOG_LEVEL)
 LOCAL_CFLAGS += -DBINARY_PREFIX=\"TEEC\"
 
 LOCAL_SRC_FILES := libteec/src/tee_client_api.c\
-                  libteec/src/teec_trace.c
+                   libteec/src/teec_trace.c
+ifeq ($(CFG_TEE_BENCHMARK),y)
+LOCAL_CFLAGS += -DCFG_TEE_BENCHMARK
+LOCAL_SRC_FILES += teec_benchmark.c
+endif
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/public \
                     $(LOCAL_PATH)/libteec/include \

--- a/libteec/Makefile
+++ b/libteec/Makefile
@@ -16,8 +16,10 @@ LIB_MAJOR	:= $(LIB_NAME).$(MAJOR_VERSION)
 LIB_MAJ_MIN	:= $(LIB_NAME).$(MAJOR_VERSION).$(MINOR_VERSION)
 
 TEEC_SRCS	:= tee_client_api.c \
-			teec_trace.c \
-			teec_benchmark.c
+		   teec_trace.c
+ifeq ($(CFG_TEE_BENCHMARK),y)
+TEEC_SRCS	+= teec_benchmark.c
+endif
 
 TEEC_SRC_DIR	:= src
 TEEC_OBJ_DIR	:= $(OUT_DIR)

--- a/libteec/include/teec_benchmark.h
+++ b/libteec/include/teec_benchmark.h
@@ -28,9 +28,10 @@
 #ifndef __TEEC_BENCHMARK_H
 #define __TEEC_BENCHMARK_H
 
-#include <stdbool.h>
-#include <tee_bench.h>
-
-bool benchmark_check_mode(void);
+#ifdef CFG_TEE_BENCHMARK
 void bm_timestamp(void);
+#else
+static inline void bm_timestamp(void) {}
+#endif
+
 #endif /* __TEEC_BENCHMARK_H */

--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -29,24 +29,24 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <pthread.h>
-#include <string.h>
-#include <stdio.h>
 #include <stdbool.h>
-#include <sys/types.h>
+#include <stdio.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#include <tee_client_api.h>
+#include <sys/types.h>
 #include <tee_client_api_extensions.h>
+#include <tee_client_api.h>
+#include <teec_trace.h>
 #include <unistd.h>
 
 #ifndef __aligned
 #define __aligned(x) __attribute__((__aligned__(x)))
 #endif
 #include <linux/tee.h>
-#include <linux/teec_benchmark.h>
 
-#include <teec_trace.h>
+#include "teec_benchmark.h"
 
 /* How many device sequence numbers will be tried before giving up */
 #define TEEC_MAX_DEV_SEQ	10

--- a/libteec/src/teec_benchmark.c
+++ b/libteec/src/teec_benchmark.c
@@ -26,20 +26,21 @@
  */
 #include <err.h>
 #include <fcntl.h>
-#include <linux/teec_benchmark.h>
 #include <math.h>
 #include <pthread.h>
 #include <sched.h>
 #include <stdbool.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <tee_bench.h>
 #include <tee_client_api.h>
 #include <unistd.h>
 
-#ifdef CFG_TEE_BENCHMARK
+#include "teec_benchmark.h"
+
 struct tee_ts_global *bench_ts_global;
 static const TEEC_UUID pta_benchmark_uuid = PTA_BENCHMARK_UUID;
 
@@ -139,7 +140,7 @@ static void *mmap_paddr(intptr_t paddr, uint64_t size)
 }
 
 /* check if we are in benchmark mode */
-bool benchmark_check_mode(void)
+static bool benchmark_check_mode(void)
 {
 	uint64_t ts_buf_raw = 0;
 	uint64_t ts_buf_size = 0;
@@ -211,7 +212,4 @@ void bm_timestamp(void)
 error:
 	pthread_mutex_unlock(&teec_bench_mu);
 }
-#else /* CFG_TEE_BENCHMARK */
-void bm_timestamp(void) {}
-#endif /* CFG_TEE_BENCHMARK */
 


### PR DESCRIPTION
Some cleanup which should also fix a build error on Android:

external/optee_client/libteec/src/tee_client_api.c:556: error: undefined reference to 'bm_timestamp'
external/optee_client/libteec/src/tee_client_api.c:592: error: undefined reference to 'bm_timestamp'
clang.real: error: linker command failed with exit code 1 (use -v to see invocation)

- Move include/linux/teec_benchmark.h up one level, because this file
is not related to the Linux TEE driver
- Make bm_timestamp() a no-op static inline if CFG_TEE_BENCHMARK != y
- Remove conditional compilation in teec_benchmark.c, instead, add the
file to the build only when CFG_TEE_BENCHMARK = y
- Declare benchmark_check_mode() static in teec_benchmark.c, since it
is not used anywhere else

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>