### PR TITLE
Makefile: preserve links to libraries during make copy_export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,6 @@ distclean: clean
 
 copy_export: build
 	mkdir -p $(DESTDIR)$(BINDIR) $(DESTDIR)$(LIBDIR) $(DESTDIR)$(INCLUDEDIR)
-	cp ${O}/libteec/libteec.so* $(DESTDIR)$(LIBDIR)
+	cp -a ${O}/libteec/libteec.so* $(DESTDIR)$(LIBDIR)
 	cp ${O}/tee-supplicant/tee-supplicant $(DESTDIR)$(BINDIR)
 	cp public/*.h $(DESTDIR)$(INCLUDEDIR)

--- a/libteec/Makefile
+++ b/libteec/Makefile
@@ -40,8 +40,8 @@ TEEC_LFLAGS    := -lpthread
 TEEC_LIBRARY	:= $(OUT_DIR)/$(LIB_MAJ_MIN)
 
 libteec: $(TEEC_LIBRARY)
-	$(VPREFIX)ln -sf $(TEEC_LIBRARY) $(OUT_DIR)/$(LIB_MAJOR)
-	$(VPREFIX)ln -sf $(OUT_DIR)/$(LIB_MAJOR) $(OUT_DIR)/$(LIB_NAME)
+	$(VPREFIX)ln -sf $(LIB_MAJ_MIN) $(OUT_DIR)/$(LIB_MAJOR)
+	$(VPREFIX)ln -sf $(LIB_MAJOR) $(OUT_DIR)/$(LIB_NAME)
 
 $(TEEC_LIBRARY): $(TEEC_OBJS)
 	@echo "  LINK    $@"


### PR DESCRIPTION
During "make copy_export" and "make install" the shared library is
copied into the LIBDIR. However "cp" is used, thus the links to the
shared library are not preserved. This patch fixes the problem by using
"cp -a" instead.

Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>