### PR TITLE
rpi3: fix unsupported exclusive access issue

### DIFF
--- a/libteec/src/teec_benchmark.c
+++ b/libteec/src/teec_benchmark.c
@@ -121,7 +121,7 @@ static void *mmap_paddr(intptr_t paddr, uint64_t size)
 	off_t page_addr;
 	intptr_t *hw_addr = (intptr_t *)paddr;
 
-	devmem = open("/dev/mem", O_RDWR | O_SYNC);
+	devmem = open("/dev/mem", O_RDWR);
 	if (!devmem)
 		return NULL;
 


### PR DESCRIPTION
Fix unsupported exclusive issue , which occurs when using gcc builtin
atomic
__sync_fetch_and_add();, which is unfolded into LDXR/STLXR pair
(aarch64).

Currently, __sync_fetch_and_add() is used in bm_timestamp() for updating
head/tail
of timestamp per-cpu ringbuffers.

```
Fixes: https://github.com/OP-TEE/optee_client/issues/99
Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>
```