### PR TITLE
tee_client_api: support calling libteec from cplusplus

### DIFF
--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -29,6 +29,10 @@
 #ifndef TEE_CLIENT_API_H
 #define TEE_CLIENT_API_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <stddef.h>
 #include <limits.h>
@@ -534,5 +538,9 @@ void TEEC_ReleaseSharedMemory(TEEC_SharedMemory *sharedMemory);
  *                  or invoke.
  */
 void TEEC_RequestCancellation(TEEC_Operation *operation);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/public/tee_client_api_extensions.h
+++ b/public/tee_client_api_extensions.h
@@ -29,6 +29,10 @@
 
 #include <tee_client_api.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * TEEC_RegisterMemoryFileDescriptor() - Register a block of existing memory as
  * a shared block within the scope of the specified context.
@@ -45,5 +49,9 @@
 TEEC_Result TEEC_RegisterSharedMemoryFileDescriptor(TEEC_Context *context,
 						    TEEC_SharedMemory *sharedMem,
 						    int fd);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TEE_CLIENT_API_EXTENSIONS_H */

--- a/public/teec_trace.h
+++ b/public/teec_trace.h
@@ -26,6 +26,11 @@
  */
 #ifndef TEEC_TRACE_H
 #define TEEC_TRACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <string.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -134,5 +139,9 @@ int _dprintf(const char *function, int flen, int line, int level,
  * @return void
  */
 void dump_buffer(const char *bname, const uint8_t *buffer, size_t blen);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
The tee client api has got no restriction for cplusplus program,
simplely add extern "c" in this patch to support this feature.

Signed-off-by: Zeng Tao <prime.zeng@hisilicon.com>