### PR TITLE
benchmark: use arm generic timers as time/tick source

### DIFF
--- a/public/tee_bench.h
+++ b/public/tee_bench.h
@@ -39,13 +39,8 @@
 #define BENCHMARK_CMD_GET_MEMREF		BENCHMARK_CMD(2)
 #define BENCHMARK_CMD_UNREGISTER		BENCHMARK_CMD(3)
 
-/*
- * Cycle count divider is enabled (in PMCR),
- * CCNT value is incremented every 64th clock cycle
- */
-#define TEE_BENCH_DIVIDER		64
 /* max amount of timestamps per buffer */
-#define TEE_BENCH_MAX_STAMPS	32
+#define TEE_BENCH_MAX_STAMPS	128
 #define TEE_BENCH_MAX_MASK		(TEE_BENCH_MAX_STAMPS - 1)
 
 /* OP-TEE susbsystems ids */
@@ -72,6 +67,7 @@ struct tee_ts_cpu_buf {
 /* memory layout for shared memory, where timestamps will be stored */
 struct tee_ts_global {
 	uint64_t cores;
+	uint64_t freq;
 	struct tee_ts_cpu_buf cpu_buf[];
 };
 #endif /* TEE_BENCH_H */


### PR DESCRIPTION
Switching to ARM Generic timers solves these problems:
1. Avoid any collisions with linux kernel perf subsystem when using PMU
as a tick source. Although perf subystem has a kernel
API(perf_event_create_kernel_counter etc.), unfortunately it doesn't
have any capabilites to enable EL0 access to cycle counter on
armv7/armv8 architectures (only for x86 platforms, where it's possible
to set bit which permits executing rdtsc from usermode)
2. Avoid any conditions, when frequency scaling occurs (moslty different
power states), or core is in wait-for-interrupt/wait-for-events states
(PMU doesn't count CPU cycles in these states).
3. Common tick source for all cores with fixed frequency

PL1 physical timer runs at frequency typically in the range 1-50MHz.

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`