### PR TITLE
tee-supplicant: REE fs open file with O_SYNC flag

### DIFF
--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -134,7 +134,7 @@ static int open_wrapper(const char *fname, int flags)
 	int fd;
 
 	while (true) {
-		fd = open(fname, flags, 0600);
+		fd = open(fname, flags | O_SYNC, 0600);
 		if (fd >= 0 || errno != EINTR)
 			return fd;
 	}


### PR DESCRIPTION
CFG_RPMB_FS=y and RPMB_EMU=0(use EMMC RPMB device). Power down when
writing file without the O_SYNC flag, dirf.db was cached by kernel,
some very old (more than two generations) version was in the file
system. If dirf.db and dirfile.db.hash (residing in RPMB) differ by
two versions, it will cause TEE_ERROR_SECURITY, and the file data
will lost.

Add O_SYNC flag in open file to fix this issue.
(fixed by Jens Wiklander)

Signed-off-by: Jianhui Li <airbak.li@hisilicon.com>
Tested-by: Jianhui Li <airbak.li@hisilicon.com> (Hisilicon)