### PR TITLE
libteec/tee-supplicant: respect LDFLAGS set from distribution toolchain

### DIFF
--- a/libteec/Makefile
+++ b/libteec/Makefile
@@ -36,7 +36,7 @@ ifeq ($(CFG_TEE_BENCHMARK),y)
 TEEC_CFLAGS	+= -DCFG_TEE_BENCHMARK
 endif
 
-TEEC_LFLAGS    := -lpthread
+TEEC_LFLAGS    := $(LDFLAGS) -lpthread
 TEEC_LIBRARY	:= $(OUT_DIR)/$(LIB_MAJ_MIN)
 
 libteec: $(TEEC_LIBRARY)

--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -55,21 +55,21 @@ ifeq ($(CFG_TA_TEST_PATH),y)
 TEES_CFLAGS	+= -DCFG_TA_TEST_PATH=1
 endif
 TEES_FILE	:= $(OUT_DIR)/$(PACKAGE_NAME)
-TEES_LDFLAGS    := -L$(OUT_DIR)/../libteec -lteec
+TEES_LFLAGS    := $(LDFLAGS) -L$(OUT_DIR)/../libteec -lteec
 
 ifeq ($(CFG_TA_GPROF_SUPPORT),y)
 TEES_CFLAGS	+= -DCFG_TA_GPROF_SUPPORT
 endif
 
-TEES_LDFLAGS	+= -lpthread
+TEES_LFLAGS	+= -lpthread
 # Needed to get clock_gettime() for for glibc versions before 2.17
-TEES_LDFLAGS	+= -lrt
+TEES_LFLAGS	+= -lrt
 
 tee-supplicant: $(TEES_FILE)
 
 $(TEES_FILE): $(TEES_OBJS)
 	@echo "  LINK    $@"
-	$(VPREFIX)$(CC) -o $@ $+ $(TEES_LDFLAGS)
+	$(VPREFIX)$(CC) -o $@ $+ $(TEES_LFLAGS)
 	@echo ""
 
 $(TEES_OBJ_DIR)/%.o: $(TEES_SRC_DIR)/%.c


### PR DESCRIPTION
Unify LFLAGS/LDFLAGS variable.

For example, on OpenEmbedded, it fixes the following QA error:
QA Issue:
No GNU_HASH in the elf binary: optee-client/usr/bin/tee-supplicant'
No GNU_HASH in the elf binary: optee-client/usr/lib/libteec.so.1.0' [ldflags]

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>