### PR TITLE
tee-supplicant: fix gcc warning

### DIFF
--- a/tee-supplicant/src/tee_socket.c
+++ b/tee-supplicant/src/tee_socket.c
@@ -379,7 +379,7 @@ static TEEC_Result poll_with_timeout(struct pollfd *pfd, nfds_t nfds,
 				     uint32_t timeout)
 {
 	struct timespec now;
-	struct timespec until;
+	struct timespec until = { 0, 0 }; /* gcc warning */
 	int to = 0;
 	int r;
 


### PR DESCRIPTION
Fixes gcc warning:
src/tee_socket.c: In function 'poll_with_timeout.constprop':
src/tee_socket.c:361:28: error: 'until.tv_nsec' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  diff.tv_nsec = a->tv_nsec - b->tv_nsec;
                 ~~~~~~~~~~~^~~~~~~~~~~~
src/tee_socket.c:382:18: note: 'until.tv_nsec' was declared here
  struct timespec until;
                  ^~~~~
src/tee_socket.c:360:26: error: 'until.tv_sec' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  diff.tv_sec = a->tv_sec - b->tv_sec;
                ~~~~~~~~~~^~~~~~~~~~~
src/tee_socket.c:382:18: note: 'until.tv_sec' was declared here
  struct timespec until;
                  ^~~~~
cc1: all warnings being treated as errors

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>