### PR TITLE
tee-supplicant: cast sizeof(x) to socklen_t

### DIFF
--- a/tee-supplicant/src/tee_socket.c
+++ b/tee-supplicant/src/tee_socket.c
@@ -548,7 +548,7 @@ static TEEC_Result sa_set_port(struct sockaddr *sa, socklen_t slen,
 	if (sa->sa_family == AF_INET) {
 		struct sockaddr_in *sain = (void *)sa;
 
-		if (slen < sizeof(*sain))
+		if (slen < (socklen_t)sizeof(*sain))
 			return TEEC_ERROR_BAD_PARAMETERS;
 		sain->sin_port = htons(port);
 
@@ -558,7 +558,7 @@ static TEEC_Result sa_set_port(struct sockaddr *sa, socklen_t slen,
 	if (sa->sa_family == AF_INET6) {
 		struct sockaddr_in6 *sain6 = (void *)sa;
 
-		if (slen < sizeof(*sain6))
+		if (slen < (socklen_t)sizeof(*sain6))
 			return TEEC_ERROR_BAD_PARAMETERS;
 		sain6->sin6_port = htons(port);
 
@@ -574,7 +574,7 @@ static TEEC_Result sa_get_port(struct sockaddr *sa, socklen_t slen,
 	if (sa->sa_family == AF_INET) {
 		struct sockaddr_in *sain = (void *)sa;
 
-		if (slen < sizeof(*sain))
+		if (slen < (socklen_t)sizeof(*sain))
 			return TEEC_ERROR_BAD_PARAMETERS;
 		*port = ntohs(sain->sin_port);
 
@@ -584,7 +584,7 @@ static TEEC_Result sa_get_port(struct sockaddr *sa, socklen_t slen,
 	if (sa->sa_family == AF_INET6) {
 		struct sockaddr_in6 *sain6 = (void *)sa;
 
-		if (slen < sizeof(*sain6))
+		if (slen < (socklen_t)sizeof(*sain6))
 			return TEEC_ERROR_BAD_PARAMETERS;
 		*port = ntohs(sain6->sin6_port);
 


### PR DESCRIPTION
Fixes compilation warnings on Android:

 optee_client/tee-supplicant/src/tee_socket.c:551:12: error: comparison of integers of different signs: 'socklen_t' (aka 'int') and 'unsigned int' [-Werror,-Wsign-compare]
                 if (slen < sizeof(*sain))
                     ~~~~ ^ ~~~~~~~~~~~~~
 optee_client/tee-supplicant/src/tee_socket.c:561:12: error: comparison of integers of different signs: 'socklen_t' (aka 'int') and 'unsigned int' [-Werror,-Wsign-compare]
                 if (slen < sizeof(*sain6))
                     ~~~~ ^ ~~~~~~~~~~~~~~
 optee_client/tee-supplicant/src/tee_socket.c:577:12: error: comparison of integers of different signs: 'socklen_t' (aka 'int') and 'unsigned int' [-Werror,-Wsign-compare]
                 if (slen < sizeof(*sain))
                     ~~~~ ^ ~~~~~~~~~~~~~
 optee_client/tee-supplicant/src/tee_socket.c:587:12: error: comparison of integers of different signs: 'socklen_t' (aka 'int') and 'unsigned int' [-Werror,-Wsign-compare]
                 if (slen < sizeof(*sain6))
                     ~~~~ ^ ~~~~~~~~~~~~~~

socklen_t may be signed or unsigned, depending on which standard is
implemented. For instance, the Single UNIX Specification V2 [1] defines
it as unsigned, while the more recent Open Group Base Specifications
Issue 7 [2] does not mention signedness.

Therefore, cast sizeof(x) to socklen_t to avoid any sign mismatch.

Link: [1] http://pubs.opengroup.org/onlinepubs/7908799/xns/syssocket.h.html
Link: [2] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Reported-by: Angela Stegmaier <angelabaker@ti.com>