### PR TITLE
tee-supplicant: cmake: enable RPMB emulation by default

### DIFF
--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -4,6 +4,7 @@ project (tee-supplicant C)
 # Configuration flags always included
 ################################################################################
 option (CFG_TA_TEST_PATH "Enable tee-supplicant to load from test/debug path" ON)
+option (RPMB_EMU "Enable tee-supplicant to emulate RPMB" ON)
 option (CFG_TA_GPROF_SUPPORT "Enabled tee-supplicant profiling support" OFF)
 
 set (CFG_TEE_SUPP_LOG_LEVEL "1" CACHE STRING "tee-supplicant log level")
@@ -60,6 +61,11 @@ endif()
 if (CFG_TA_TEST_PATH)
 	target_compile_definitions (${PROJECT_NAME}
 		PRIVATE -DCFG_TA_TEST_PATH=${CFG_TA_TEST_PATH})
+endif()
+
+if (CFG_TA_TEST_PATH)
+	target_compile_definitions (${PROJECT_NAME}
+		PRIVATE -DRPMB_EMU=1)
 endif()
 
 if (CFG_TA_GPROF_SUPPORT)


### PR DESCRIPTION
Enables RPMB emulation by default also when compiling with cmake.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>