### PR TITLE
libteec: Makefile: Generate .so files the same way as CMake

### DIFF
--- a/libteec/Makefile
+++ b/libteec/Makefile
@@ -11,9 +11,11 @@ all: libteec
 ################################################################################
 MAJOR_VERSION	:= 1
 MINOR_VERSION	:= 0
+PATCH_VERSION	:= 0
 LIB_NAME	:= libteec.so
 LIB_MAJOR	:= $(LIB_NAME).$(MAJOR_VERSION)
 LIB_MAJ_MIN	:= $(LIB_NAME).$(MAJOR_VERSION).$(MINOR_VERSION)
+LIB_MAJ_MIN_P	:= $(LIB_NAME).$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 
 TEEC_SRCS	:= tee_client_api.c \
 		   teec_trace.c
@@ -37,15 +39,16 @@ TEEC_CFLAGS	+= -DCFG_TEE_BENCHMARK
 endif
 
 TEEC_LFLAGS    := $(LDFLAGS) -lpthread
-TEEC_LIBRARY	:= $(OUT_DIR)/$(LIB_MAJ_MIN)
+TEEC_LIBRARY	:= $(OUT_DIR)/$(LIB_MAJ_MIN_P)
 
 libteec: $(TEEC_LIBRARY) $(OUT_DIR)/libteec.a
-	$(VPREFIX)ln -sf $(LIB_MAJ_MIN) $(OUT_DIR)/$(LIB_MAJOR)
+	$(VPREFIX)ln -sf $(LIB_MAJ_MIN_P) $(OUT_DIR)/$(LIB_MAJOR)
+	$(VPREFIX)ln -sf $(LIB_MAJ_MIN_P) $(OUT_DIR)/$(LIB_MAJ_MIN)
 	$(VPREFIX)ln -sf $(LIB_MAJOR) $(OUT_DIR)/$(LIB_NAME)
 
 $(TEEC_LIBRARY): $(TEEC_OBJS)
 	@echo "  LINK    $@"
-	$(VPREFIX)$(CC) -shared -Wl,-soname,$(LIB_MAJ_MIN) $(TEEC_LFLAGS) -o $@ $+
+	$(VPREFIX)$(CC) -shared -Wl,-soname,$(LIB_MAJOR) $(TEEC_LFLAGS) -o $@ $+
 	@echo ""
 
 $(OUT_DIR)/libteec.a: $(TEEC_OBJS)
@@ -61,6 +64,7 @@ $(TEEC_OBJ_DIR)/%.o: ${TEEC_SRC_DIR}/%.c
 # Cleaning up configuration
 ################################################################################
 clean:
-	$(RM) $(TEEC_OBJS) $(TEEC_LIBRARY) $(OUT_DIR)/$(LIB_MAJOR) $(OUT_DIR)/$(LIB_NAME)
+	$(RM) $(TEEC_OBJS) $(TEEC_LIBRARY) $(OUT_DIR)/$(LIB_MAJOR) \
+		$(OUT_DIR)/$(LIB_MAJ_MIN) $(OUT_DIR)/$(LIB_NAME)
 	$(RM) $(OUT_DIR)/libteec.a
 	$(call rmdir,$(OUT_DIR))


### PR DESCRIPTION
The Makefile currently generates a libteec.so file that has the SONAME "libteec.so.1.0". By contrast, the CMake script generates libteec.so with the SONAME "libteec.so.1". An application that has been linked against the Makefile version of libteec.so expects the file libteec.so.1.0 to be present in the runtime environment. However, no such file is generated by the CMake script which means the application cannot be executed in an environment for which libteec was built with CMake.

The proposed change modifies the Makefile so that it generates libteec.so and the corresponding symlinks in exactly the same way as the CMake script. That is, both the Makefile and the CMake script generate a library with the SONAME "libteec.so.1" as well as the symlinks libteec.so and libteec.so.1.

An alternative approach would have been to modify the CMake script so it behaves like the Makefile. However, the SONAME "libteec.so.1" strikes me as more natural which is why I propose adjusting the Makefile instead.