### PR TITLE
tee_supplicant: gprof: fix compile error

### DIFF
--- a/tee-supplicant/src/gprof.c
+++ b/tee-supplicant/src/gprof.c
@@ -94,6 +94,8 @@ TEEC_Result gprof_process(size_t num_params, struct tee_ioctl_param *params)
 			 * id == 1 is file 0 (no suffix), id == 2 is file .1
 			 * etc.
 			 */
+			if (id > 100)
+				id = 100; /* Avoid GCC truncation warning */
 			snprintf(vers, sizeof(vers), ".%d", id - 1);
 		}
 		n = snprintf(path, sizeof(path),


### PR DESCRIPTION
Avoids a compile error with using GCC 8.x with CFG_TA_GPROF_SUPPORT=y:

 src/gprof.c: In function ‘gprof_process’:
 src/gprof.c:97:35: error: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 4 [-Werror=format-truncation=]
     snprintf(vers, sizeof(vers), ".%d", id - 1);
                                    ^~
 src/gprof.c:97:33: note: directive argument in the range [1, 2147483646]
     snprintf(vers, sizeof(vers), ".%d", id - 1);
                                  ^~~~~
 src/gprof.c:97:4: note: ‘snprintf’ output between 3 and 12 bytes into a destination of size 5
     snprintf(vers, sizeof(vers), ".%d", id - 1);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 cc1: all warnings being treated as errors

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>