### PR TITLE
flags: add -D_FILE_OFFSET_BITS=64 to support large files

### DIFF
--- a/flags.mk
+++ b/flags.mk
@@ -14,7 +14,7 @@ CFLAGS          := -Wall -Wbad-function-cast -Wcast-align \
 		   -Wmissing-noreturn -Wmissing-prototypes -Wnested-externs \
 		   -Wpointer-arith -Wshadow -Wstrict-prototypes \
 		   -Wswitch-default -Wunsafe-loop-optimizations \
-		   -Wwrite-strings
+		   -Wwrite-strings -D_FILE_OFFSET_BITS=64
 ifeq ($(CFG_WERROR),y)
 CFLAGS		+= -Werror
 endif


### PR DESCRIPTION
The tee client library does not need to provide compatibility for the old file
system interface.

Fixes #140

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>