### PR TITLE
tee-supplicant: fix cmake to install in bin/ not sbin/

### DIFF
--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -85,4 +85,4 @@ target_link_libraries (${PROJECT_NAME}
 ################################################################################
 # Install targets
 ################################################################################
-install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_SBINDIR})
+install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
GNU makefile and Android makefile both install tee-supplicant
in the bin/ directory. Prio this change CMakeLists.txt installed
tee-supplicant in the sbin/ directory. This change fixes the
CMake script to intall tee-supplicant in direcory bin/.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>