### PR TITLE
tee-supplicant: fix install path in GNU makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ export VPREFIX
 
 EXPORT_DIR ?= $(O)/export
 DESTDIR ?= $(EXPORT_DIR)
-BINDIR ?= /bin
 LIBDIR ?= /lib
 INCLUDEDIR ?= /include
+SBINDIR ?= /usr/sbin
 
 CFG_TA_GPROF_SUPPORT ?= n
 
@@ -124,8 +124,8 @@ checkpatch-all-files: checkpatch-pre-req
 distclean: clean
 
 copy_export: build
-	mkdir -p $(DESTDIR)$(BINDIR) $(DESTDIR)$(LIBDIR) $(DESTDIR)$(INCLUDEDIR)
+	mkdir -p $(DESTDIR)$(SBINDIR) $(DESTDIR)$(LIBDIR) $(DESTDIR)$(INCLUDEDIR)
 	cp -a ${O}/libteec/libteec.so* $(DESTDIR)$(LIBDIR)
 	cp -a ${O}/libteec/libteec.a $(DESTDIR)$(LIBDIR)
-	cp ${O}/tee-supplicant/tee-supplicant $(DESTDIR)$(BINDIR)
+	cp ${O}/tee-supplicant/tee-supplicant $(DESTDIR)$(SBINDIR)
 	cp public/*.h $(DESTDIR)$(INCLUDEDIR)

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ export VPREFIX
 
 EXPORT_DIR ?= $(O)/export
 DESTDIR ?= $(EXPORT_DIR)
-LIBDIR ?= /lib
-INCLUDEDIR ?= /include
 SBINDIR ?= /usr/sbin
+LIBDIR ?= /usr/lib
+INCLUDEDIR ?= /usr/include
 
 CFG_TA_GPROF_SUPPORT ?= n
 


### PR DESCRIPTION
Change GNU makefile to default install **tee-supplicant** in target directory **/bin** instead of **/sbin**.

This change aligns the GNU makefile install sequence with the CMake install sequence.