### PR TITLE
Fix build warnings and initialize functions local variables

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -66,8 +66,10 @@ static void teec_mutex_unlock(pthread_mutex_t *mu)
 static int teec_open_dev(const char *devname, const char *capabilities,
 			 uint32_t *gen_caps)
 {
-	struct tee_ioctl_version_data vers = { 0 };
 	int fd = 0;
+	struct tee_ioctl_version_data vers;
+
+	memset(&vers, 0, sizeof(vers));
 
 	fd = open(devname, O_RDWR);
 	if (fd < 0)
@@ -104,9 +106,10 @@ err:
 static int teec_shm_alloc(int fd, size_t size, int *id)
 {
 	int shm_fd = 0;
-	struct tee_ioctl_shm_alloc_data data = { 0 };
+	struct tee_ioctl_shm_alloc_data data;
 
 	memset(&data, 0, sizeof(data));
+
 	data.size = size;
 	shm_fd = ioctl(fd, TEE_IOC_SHM_ALLOC, &data);
 	if (shm_fd < 0)
@@ -118,9 +121,10 @@ static int teec_shm_alloc(int fd, size_t size, int *id)
 static int teec_shm_register(int fd, void *buf, size_t size, int *id)
 {
 	int shm_fd = 0;
-	struct tee_ioctl_shm_register_data data = { 0 };
+	struct tee_ioctl_shm_register_data data;
 
 	memset(&data, 0, sizeof(data));
+
 	data.addr = (uintptr_t)buf;
 	data.length = size;
 	shm_fd = ioctl(fd, TEE_IOC_SHM_REGISTER, &data);
@@ -485,13 +489,16 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 			TEEC_CONFIG_PAYLOAD_REF_COUNT *
 				sizeof(struct tee_ioctl_param)) /
 			sizeof(uint64_t)] = { 0 };
-	struct tee_ioctl_buf_data buf_data = { 0 };
 	struct tee_ioctl_open_session_arg *arg = NULL;
 	struct tee_ioctl_param *params = NULL;
 	TEEC_Result res = 0;
 	uint32_t eorig = 0;
-	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT] = { 0 };
 	int rc = 0;
+	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
+	struct tee_ioctl_buf_data buf_data;
+
+	memset(&shm, 0, sizeof(shm));
+	memset(&buf_data, 0, sizeof(buf_data));
 
 	(void)&connection_data;
 
@@ -542,7 +549,9 @@ out:
 
 void TEEC_CloseSession(TEEC_Session *session)
 {
-	struct tee_ioctl_close_session_arg arg = { 0 };
+	struct tee_ioctl_close_session_arg arg;
+
+	memset(&arg, 0, sizeof(arg));
 
 	if (!session)
 		return;
@@ -559,13 +568,16 @@ TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
 			TEEC_CONFIG_PAYLOAD_REF_COUNT *
 				sizeof(struct tee_ioctl_param)) /
 			sizeof(uint64_t)] = { 0 };
-	struct tee_ioctl_buf_data buf_data = { 0 };
 	struct tee_ioctl_invoke_arg *arg = NULL;
 	struct tee_ioctl_param *params = NULL;
 	TEEC_Result res = 0;
 	uint32_t eorig = 0;
-	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT] = { 0 };
 	int rc = 0;
+	struct tee_ioctl_buf_data buf_data;
+	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
+
+	memset(&buf_data, 0, sizeof(buf_data));
+	memset(&shm, 0, sizeof(shm));
 
 	if (!session) {
 		eorig = TEEC_ORIGIN_API;
@@ -621,8 +633,10 @@ out:
 
 void TEEC_RequestCancellation(TEEC_Operation *operation)
 {
-	struct tee_ioctl_cancel_arg arg = { 0 };
 	TEEC_Session *session = NULL;
+	struct tee_ioctl_cancel_arg arg;
+
+	memset(&arg, 0, sizeof(arg));
 
 	if (!operation)
 		return;
@@ -685,8 +699,10 @@ TEEC_Result TEEC_RegisterSharedMemoryFileDescriptor(TEEC_Context *ctx,
 						    TEEC_SharedMemory *shm,
 						    int fd)
 {
-	struct tee_ioctl_shm_register_fd_data data = { 0 };
 	int rfd = 0;
+	struct tee_ioctl_shm_register_fd_data data;
+
+	memset(&data, 0, sizeof(data));
 
 	if (!ctx || !shm || fd < 0)
 		return TEEC_ERROR_BAD_PARAMETERS;

--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -485,20 +485,23 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 			uint32_t connection_method, const void *connection_data,
 			TEEC_Operation *operation, uint32_t *ret_origin)
 {
-	uint64_t buf[(sizeof(struct tee_ioctl_open_session_arg) +
-			TEEC_CONFIG_PAYLOAD_REF_COUNT *
-				sizeof(struct tee_ioctl_param)) /
-			sizeof(uint64_t)] = { 0 };
-	struct tee_ioctl_open_session_arg *arg = NULL;
 	struct tee_ioctl_param *params = NULL;
 	TEEC_Result res = 0;
 	uint32_t eorig = 0;
 	int rc = 0;
+	size_t par_sz = TEEC_CONFIG_PAYLOAD_REF_COUNT *
+			sizeof(struct tee_ioctl_param);
+	union {
+	    struct tee_ioctl_open_session_arg arg;
+	    uint8_t data[sizeof(struct tee_ioctl_open_session_arg) + par_sz];
+	} buf;
+	struct tee_ioctl_open_session_arg *arg = NULL;
 	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
 	struct tee_ioctl_buf_data buf_data;
 
 	memset(&shm, 0, sizeof(shm));
 	memset(&buf_data, 0, sizeof(buf_data));
+	memset(&buf, 0, sizeof(buf));
 
 	(void)&connection_data;
 
@@ -508,10 +511,10 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 		goto out;
 	}
 
-	buf_data.buf_ptr = (uintptr_t)buf;
+	buf_data.buf_ptr = (uintptr_t)&buf;
 	buf_data.buf_len = sizeof(buf);
 
-	arg = (struct tee_ioctl_open_session_arg *)(void *)buf;
+	arg = &buf.arg;
 	arg->num_params = TEEC_CONFIG_PAYLOAD_REF_COUNT;
 	params = (struct tee_ioctl_param *)(arg + 1);
 
@@ -564,20 +567,23 @@ void TEEC_CloseSession(TEEC_Session *session)
 TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
 			TEEC_Operation *operation, uint32_t *error_origin)
 {
-	uint64_t buf[(sizeof(struct tee_ioctl_invoke_arg) +
-			TEEC_CONFIG_PAYLOAD_REF_COUNT *
-				sizeof(struct tee_ioctl_param)) /
-			sizeof(uint64_t)] = { 0 };
-	struct tee_ioctl_invoke_arg *arg = NULL;
 	struct tee_ioctl_param *params = NULL;
 	TEEC_Result res = 0;
 	uint32_t eorig = 0;
 	int rc = 0;
+	size_t par_sz = TEEC_CONFIG_PAYLOAD_REF_COUNT *
+			sizeof(struct tee_ioctl_param);
+	union {
+	    struct tee_ioctl_invoke_arg arg;
+	    uint8_t data[sizeof(struct tee_ioctl_invoke_arg) + par_sz];
+	} buf;
+	struct tee_ioctl_invoke_arg *arg = NULL;
 	struct tee_ioctl_buf_data buf_data;
 	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
 
 	memset(&buf_data, 0, sizeof(buf_data));
 	memset(&shm, 0, sizeof(shm));
+	memset(&buf, 0, sizeof(buf));
 
 	if (!session) {
 		eorig = TEEC_ORIGIN_API;
@@ -587,10 +593,10 @@ TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
 
 	bm_timestamp();
 
-	buf_data.buf_ptr = (uintptr_t)buf;
+	buf_data.buf_ptr = (uintptr_t)&buf;
 	buf_data.buf_len = sizeof(buf);
 
-	arg = (struct tee_ioctl_invoke_arg *)(void *)buf;
+	arg = &buf.arg;
 	arg->num_params = TEEC_CONFIG_PAYLOAD_REF_COUNT;
 	params = (struct tee_ioctl_param *)(arg + 1);
 

--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -66,8 +66,8 @@ static void teec_mutex_unlock(pthread_mutex_t *mu)
 static int teec_open_dev(const char *devname, const char *capabilities,
 			 uint32_t *gen_caps)
 {
-	struct tee_ioctl_version_data vers;
-	int fd;
+	struct tee_ioctl_version_data vers = { 0 };
+	int fd = 0;
 
 	fd = open(devname, O_RDWR);
 	if (fd < 0)
@@ -103,8 +103,8 @@ err:
 
 static int teec_shm_alloc(int fd, size_t size, int *id)
 {
-	int shm_fd;
-	struct tee_ioctl_shm_alloc_data data;
+	int shm_fd = 0;
+	struct tee_ioctl_shm_alloc_data data = { 0 };
 
 	memset(&data, 0, sizeof(data));
 	data.size = size;
@@ -117,8 +117,8 @@ static int teec_shm_alloc(int fd, size_t size, int *id)
 
 static int teec_shm_register(int fd, void *buf, size_t size, int *id)
 {
-	int shm_fd;
-	struct tee_ioctl_shm_register_data data;
+	int shm_fd = 0;
+	struct tee_ioctl_shm_register_data data = { 0 };
 
 	memset(&data, 0, sizeof(data));
 	data.addr = (uintptr_t)buf;
@@ -132,9 +132,9 @@ static int teec_shm_register(int fd, void *buf, size_t size, int *id)
 
 TEEC_Result TEEC_InitializeContext(const char *name, TEEC_Context *ctx)
 {
-	char devname[PATH_MAX];
-	int fd;
-	size_t n;
+	char devname[PATH_MAX] = { 0 };
+	int fd = 0;
+	size_t n = 0;
 
 	if (!ctx)
 		return TEEC_ERROR_BAD_PARAMETERS;
@@ -166,7 +166,7 @@ static TEEC_Result teec_pre_process_tmpref(TEEC_Context *ctx,
 			struct tee_ioctl_param *param,
 			TEEC_SharedMemory *shm)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 
 	switch (param_type) {
 	case TEEC_MEMREF_TEMP_INPUT:
@@ -202,7 +202,7 @@ static TEEC_Result teec_pre_process_whole(
 {
 	const uint32_t inout = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT;
 	uint32_t flags = memref->parent->flags & inout;
-	TEEC_SharedMemory *shm;
+	TEEC_SharedMemory *shm = NULL;
 
 	if (flags == inout)
 		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INOUT;
@@ -231,8 +231,8 @@ static TEEC_Result teec_pre_process_partial(uint32_t param_type,
 			TEEC_RegisteredMemoryReference *memref,
 			struct tee_ioctl_param *param)
 {
-	uint32_t req_shm_flags;
-	TEEC_SharedMemory *shm;
+	uint32_t req_shm_flags = 0;
+	TEEC_SharedMemory *shm = NULL;
 
 	switch (param_type) {
 	case TEEC_MEMREF_PARTIAL_INPUT:
@@ -276,8 +276,8 @@ static TEEC_Result teec_pre_process_operation(TEEC_Context *ctx,
 			struct tee_ioctl_param *params,
 			TEEC_SharedMemory *shms)
 {
-	TEEC_Result res;
-	size_t n;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	size_t n = 0;
 
 	memset(shms, 0, sizeof(TEEC_SharedMemory) *
 			TEEC_CONFIG_PAYLOAD_REF_COUNT);
@@ -288,7 +288,7 @@ static TEEC_Result teec_pre_process_operation(TEEC_Context *ctx,
 	}
 
 	for (n = 0; n < TEEC_CONFIG_PAYLOAD_REF_COUNT; n++) {
-		uint32_t param_type;
+		uint32_t param_type = 0;
 
 		param_type = TEEC_PARAM_TYPE_GET(operation->paramTypes, n);
 		switch (param_type) {
@@ -393,13 +393,13 @@ static void teec_post_process_operation(TEEC_Operation *operation,
 			struct tee_ioctl_param *params,
 			TEEC_SharedMemory *shms)
 {
-	size_t n;
+	size_t n = 0;
 
 	if (!operation)
 		return;
 
 	for (n = 0; n < TEEC_CONFIG_PAYLOAD_REF_COUNT; n++) {
-		uint32_t param_type;
+		uint32_t param_type = 0;
 
 		param_type = TEEC_PARAM_TYPE_GET(operation->paramTypes, n);
 		switch (param_type) {
@@ -435,7 +435,7 @@ static void teec_post_process_operation(TEEC_Operation *operation,
 static void teec_free_temp_refs(TEEC_Operation *operation,
 			TEEC_SharedMemory *shms)
 {
-	size_t n;
+	size_t n = 0;
 
 	if (!operation)
 		return;
@@ -485,13 +485,13 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 			TEEC_CONFIG_PAYLOAD_REF_COUNT *
 				sizeof(struct tee_ioctl_param)) /
 			sizeof(uint64_t)] = { 0 };
-	struct tee_ioctl_buf_data buf_data;
-	struct tee_ioctl_open_session_arg *arg;
-	struct tee_ioctl_param *params;
-	TEEC_Result res;
-	uint32_t eorig;
-	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
-	int rc;
+	struct tee_ioctl_buf_data buf_data = { 0 };
+	struct tee_ioctl_open_session_arg *arg = NULL;
+	struct tee_ioctl_param *params = NULL;
+	TEEC_Result res = 0;
+	uint32_t eorig = 0;
+	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT] = { 0 };
+	int rc = 0;
 
 	(void)&connection_data;
 
@@ -542,7 +542,7 @@ out:
 
 void TEEC_CloseSession(TEEC_Session *session)
 {
-	struct tee_ioctl_close_session_arg arg;
+	struct tee_ioctl_close_session_arg arg = { 0 };
 
 	if (!session)
 		return;
@@ -559,13 +559,13 @@ TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
 			TEEC_CONFIG_PAYLOAD_REF_COUNT *
 				sizeof(struct tee_ioctl_param)) /
 			sizeof(uint64_t)] = { 0 };
-	struct tee_ioctl_buf_data buf_data;
-	struct tee_ioctl_invoke_arg *arg;
-	struct tee_ioctl_param *params;
-	TEEC_Result res;
-	uint32_t eorig;
-	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
-	int rc;
+	struct tee_ioctl_buf_data buf_data = { 0 };
+	struct tee_ioctl_invoke_arg *arg = NULL;
+	struct tee_ioctl_param *params = NULL;
+	TEEC_Result res = 0;
+	uint32_t eorig = 0;
+	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT] = { 0 };
+	int rc = 0;
 
 	if (!session) {
 		eorig = TEEC_ORIGIN_API;
@@ -621,8 +621,8 @@ out:
 
 void TEEC_RequestCancellation(TEEC_Operation *operation)
 {
-	struct tee_ioctl_cancel_arg arg;
-	TEEC_Session *session;
+	struct tee_ioctl_cancel_arg arg = { 0 };
+	TEEC_Session *session = NULL;
 
 	if (!operation)
 		return;
@@ -643,8 +643,8 @@ void TEEC_RequestCancellation(TEEC_Operation *operation)
 
 TEEC_Result TEEC_RegisterSharedMemory(TEEC_Context *ctx, TEEC_SharedMemory *shm)
 {
-	int fd;
-	size_t s;
+	int fd = 0;
+	size_t s = 0;
 
 	if (!ctx || !shm)
 		return TEEC_ERROR_BAD_PARAMETERS;
@@ -685,8 +685,8 @@ TEEC_Result TEEC_RegisterSharedMemoryFileDescriptor(TEEC_Context *ctx,
 						    TEEC_SharedMemory *shm,
 						    int fd)
 {
-	struct tee_ioctl_shm_register_fd_data data;
-	int rfd;
+	struct tee_ioctl_shm_register_fd_data data = { 0 };
+	int rfd = 0;
 
 	if (!ctx || !shm || fd < 0)
 		return TEEC_ERROR_BAD_PARAMETERS;
@@ -710,8 +710,8 @@ TEEC_Result TEEC_RegisterSharedMemoryFileDescriptor(TEEC_Context *ctx,
 
 TEEC_Result TEEC_AllocateSharedMemory(TEEC_Context *ctx, TEEC_SharedMemory *shm)
 {
-	int fd;
-	size_t s;
+	int fd = 0;
+	size_t s = 0;
 
 	if (!ctx || !shm)
 		return TEEC_ERROR_BAD_PARAMETERS;

--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -140,7 +140,7 @@ TEEC_Result TEEC_InitializeContext(const char *name, TEEC_Context *ctx)
 		return TEEC_ERROR_BAD_PARAMETERS;
 
 	for (n = 0; n < TEEC_MAX_DEV_SEQ; n++) {
-		uint32_t gen_caps;
+		uint32_t gen_caps = 0;
 
 		snprintf(devname, sizeof(devname), "/dev/tee%zu", n);
 		fd = teec_open_dev(devname, name, &gen_caps);
@@ -504,7 +504,7 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 	buf_data.buf_ptr = (uintptr_t)buf;
 	buf_data.buf_len = sizeof(buf);
 
-	arg = (struct tee_ioctl_open_session_arg *)buf;
+	arg = (struct tee_ioctl_open_session_arg *)(void *)buf;
 	arg->num_params = TEEC_CONFIG_PAYLOAD_REF_COUNT;
 	params = (struct tee_ioctl_param *)(arg + 1);
 
@@ -578,7 +578,7 @@ TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
 	buf_data.buf_ptr = (uintptr_t)buf;
 	buf_data.buf_len = sizeof(buf);
 
-	arg = (struct tee_ioctl_invoke_arg *)buf;
+	arg = (struct tee_ioctl_invoke_arg *)(void *)buf;
 	arg->num_params = TEEC_CONFIG_PAYLOAD_REF_COUNT;
 	params = (struct tee_ioctl_param *)(arg + 1);
 

--- a/libteec/src/teec_benchmark.c
+++ b/libteec/src/teec_benchmark.c
@@ -63,8 +63,8 @@ static inline uint64_t read_ccounter(void)
 
 static TEEC_Result benchmark_pta_open(void)
 {
-	TEEC_Result res;
-	uint32_t ret_orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t ret_orig = 0;
 
 	res = TEEC_InitializeContext(NULL, &bench_ctx);
 	if (res != TEEC_SUCCESS)
@@ -90,9 +90,9 @@ static void benchmark_pta_close(void)
 static TEEC_Result benchmark_get_bench_buf_paddr(uint64_t *paddr_ts_buf,
 				uint64_t *size)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = { 0 };
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	res = benchmark_pta_open();
 	if (res != TEEC_SUCCESS)
@@ -116,10 +116,10 @@ static TEEC_Result benchmark_get_bench_buf_paddr(uint64_t *paddr_ts_buf,
 
 static void *mmap_paddr(intptr_t paddr, uint64_t size)
 {
-	int   devmem;
-	off_t offset;
-	off_t page_addr;
-	intptr_t *hw_addr;
+	int devmem = 0;
+	off_t offset = 0;
+	off_t page_addr = 0;
+	intptr_t *hw_addr = NULL;
 
 	devmem = open("/dev/mem", O_RDWR);
 	if (!devmem)
@@ -163,14 +163,14 @@ static bool benchmark_check_mode(void)
 /* Adding timestamp to buffer */
 void bm_timestamp(void)
 {
-	cpu_set_t cpu_set_old;
-	cpu_set_t cpu_set_tmp;
-	struct tee_ts_cpu_buf *cpu_buf;
-	struct tee_time_st ts_data;
-	uint64_t ts_i;
-	void *ret_addr;
-	uint32_t cur_cpu;
-	int ret;
+	cpu_set_t cpu_set_old = { 0 };
+	cpu_set_t cpu_set_tmp = { 0 };
+	struct tee_ts_cpu_buf *cpu_buf = NULL;
+	struct tee_time_st ts_data = { 0 };
+	uint64_t ts_i = 0;
+	void *ret_addr = NULL;
+	uint32_t cur_cpu = 0;
+	int ret = 0;
 
 	if (pthread_mutex_trylock(&teec_bench_mu))
 		return;

--- a/libteec/src/teec_benchmark.c
+++ b/libteec/src/teec_benchmark.c
@@ -91,8 +91,10 @@ static TEEC_Result benchmark_get_bench_buf_paddr(uint64_t *paddr_ts_buf,
 				uint64_t *size)
 {
 	TEEC_Result res = TEEC_ERROR_GENERIC;
-	TEEC_Operation op = { 0 };
 	uint32_t ret_orig = 0;
+	TEEC_Operation op;
+
+	memset(&op, 0, sizeof(op));
 
 	res = benchmark_pta_open();
 	if (res != TEEC_SUCCESS)
@@ -163,14 +165,18 @@ static bool benchmark_check_mode(void)
 /* Adding timestamp to buffer */
 void bm_timestamp(void)
 {
-	cpu_set_t cpu_set_old = { 0 };
-	cpu_set_t cpu_set_tmp = { 0 };
 	struct tee_ts_cpu_buf *cpu_buf = NULL;
-	struct tee_time_st ts_data = { 0 };
 	uint64_t ts_i = 0;
 	void *ret_addr = NULL;
 	uint32_t cur_cpu = 0;
 	int ret = 0;
+	cpu_set_t cpu_set_old;
+	cpu_set_t cpu_set_tmp;
+	struct tee_time_st ts_data;
+
+	memset(&cpu_set_old, 0, sizeof(cpu_set_old));
+	memset(&cpu_set_tmp, 0, sizeof(cpu_set_tmp));
+	memset(&ts_data, 0, sizeof(ts_data));
 
 	if (pthread_mutex_trylock(&teec_bench_mu))
 		return;

--- a/libteec/src/teec_trace.c
+++ b/libteec/src/teec_trace.c
@@ -51,8 +51,7 @@
 #ifdef TEEC_LOG_FILE
 static void log_to_file(const char *buffer)
 {
-	FILE *log_file;
-	log_file = fopen(TEEC_LOG_FILE, "a");
+	FILE *log_file = fopen(TEEC_LOG_FILE, "a");
 
 	if (log_file != NULL) {
 		fprintf(log_file, "%s", buffer);
@@ -103,7 +102,7 @@ void dump_buffer(const char *bname, const uint8_t *buffer, size_t blen)
 	fprintf(stderr, "#### %s\n", bname);
 
 	while (blen > 0) {
-		size_t n;
+		size_t n = 0;
 
 		for (n = 0; n < 16; n++) {
 			if (n < blen)

--- a/tee-supplicant/src/gprof.c
+++ b/tee-supplicant/src/gprof.c
@@ -43,7 +43,7 @@
 
 TEEC_Result gprof_process(size_t num_params, struct tee_ioctl_param *params)
 {
-	char vers[5] = { 0 };
+	char vers[5] = "";
 	char path[255] = { 0 };
 	size_t bufsize = 0;
 	TEEC_UUID *u = NULL;

--- a/tee-supplicant/src/gprof.c
+++ b/tee-supplicant/src/gprof.c
@@ -43,16 +43,16 @@
 
 TEEC_Result gprof_process(size_t num_params, struct tee_ioctl_param *params)
 {
-	char vers[5] = "";
-	char path[255];
-	size_t bufsize;
-	TEEC_UUID *u;
+	char vers[5] = { 0 };
+	char path[255] = { 0 };
+	size_t bufsize = 0;
+	TEEC_UUID *u = NULL;
 	int fd = -1;
-	void *buf;
-	int flags;
-	int id;
-	int st;
-	int n;
+	void *buf = NULL;
+	int flags = 0;
+	int id = 0;
+	int st = 0;
+	int n = 0;
 
 	if (num_params != 3 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=

--- a/tee-supplicant/src/handle.c
+++ b/tee-supplicant/src/handle.c
@@ -67,10 +67,10 @@ void handle_db_destroy(struct handle_db *db)
 
 int handle_get(struct handle_db *db, void *ptr)
 {
-	size_t n;
-	void *p;
-	size_t new_max_ptrs;
-	int ret;
+	size_t n = 0;
+	void *p = NULL;
+	size_t new_max_ptrs = 0;
+	int ret = 0;
 
 	if (!db || !ptr)
 		return -1;
@@ -112,7 +112,7 @@ out:
 
 void *handle_put(struct handle_db *db, int handle)
 {
-	void *p;
+	void *p = NULL;
 
 	if (!db || handle < 0)
 		return NULL;
@@ -134,7 +134,7 @@ out:
 
 void *handle_lookup(struct handle_db *db, int handle)
 {
-	void *p;
+	void *p = NULL;
 
 	if (!db || handle < 0)
 		return NULL;
@@ -157,7 +157,7 @@ void handle_foreach_put(struct handle_db *db,
 			void (*cb)(int handle, void *ptr, void *arg),
 			void *arg)
 {
-	size_t n;
+	size_t n = 0;
 
 	if (!db || !cb)
 		return;

--- a/tee-supplicant/src/hmac_sha2.c
+++ b/tee-supplicant/src/hmac_sha2.c
@@ -43,12 +43,11 @@
 void hmac_sha256_init(hmac_sha256_ctx *ctx, const unsigned char *key,
                       unsigned int key_size)
 {
-    unsigned int fill;
-    unsigned int num;
-
-    const unsigned char *key_used;
-    unsigned char key_temp[SHA256_DIGEST_SIZE];
-    int i;
+    unsigned int fill = 0;
+    unsigned int num = 0;
+    const unsigned char *key_used = NULL;
+    unsigned char key_temp[SHA256_DIGEST_SIZE] = { 0 };
+    int i = 0;
 
     if (key_size == SHA256_BLOCK_SIZE) {
         key_used = key;
@@ -104,8 +103,8 @@ void hmac_sha256_update(hmac_sha256_ctx *ctx, const unsigned char *message,
 void hmac_sha256_final(hmac_sha256_ctx *ctx, unsigned char *mac,
                        unsigned int mac_size)
 {
-    unsigned char digest_inside[SHA256_DIGEST_SIZE];
-    unsigned char mac_temp[SHA256_DIGEST_SIZE];
+    unsigned char digest_inside[SHA256_DIGEST_SIZE] = { 0 };
+    unsigned char mac_temp[SHA256_DIGEST_SIZE] = { 0 };
 
     sha256_final(&ctx->ctx_inside, digest_inside);
     sha256_update(&ctx->ctx_outside, digest_inside, SHA256_DIGEST_SIZE);
@@ -117,7 +116,7 @@ void hmac_sha256(const unsigned char *key, unsigned int key_size,
           const unsigned char *message, unsigned int message_len,
           unsigned char *mac, unsigned mac_size)
 {
-    hmac_sha256_ctx ctx;
+    hmac_sha256_ctx ctx = { 0 };
 
     hmac_sha256_init(&ctx, key, key_size);
     hmac_sha256_update(&ctx, message, message_len);

--- a/tee-supplicant/src/hmac_sha2.c
+++ b/tee-supplicant/src/hmac_sha2.c
@@ -116,7 +116,9 @@ void hmac_sha256(const unsigned char *key, unsigned int key_size,
           const unsigned char *message, unsigned int message_len,
           unsigned char *mac, unsigned mac_size)
 {
-    hmac_sha256_ctx ctx = { 0 };
+    hmac_sha256_ctx ctx;
+
+    memset(&ctx, 0, sizeof(ctx));
 
     hmac_sha256_init(&ctx, key, key_size);
     hmac_sha256_update(&ctx, message, message_len);

--- a/tee-supplicant/src/rpmb.c
+++ b/tee-supplicant/src/rpmb.c
@@ -150,7 +150,7 @@ static int mmc_rpmb_fd(uint16_t dev_id)
 {
 	static int id;
 	static int fd = -1;
-	char path[PATH_MAX];
+	char path[PATH_MAX] = { 0 };
 
 	if (fd < 0) {
 #ifdef __ANDROID__
@@ -175,8 +175,8 @@ static int mmc_rpmb_fd(uint16_t dev_id)
 /* Open eMMC device dev_id */
 static int mmc_fd(uint16_t dev_id)
 {
-	int fd;
-	char path[PATH_MAX];
+	int fd = 0;
+	char path[PATH_MAX] = { 0 };
 
 #ifdef __ANDROID__
 	snprintf(path, sizeof(path), "/dev/block/mmcblk%u", dev_id);
@@ -198,12 +198,12 @@ static void close_mmc_fd(int fd)
 /* Device Identification (CID) register is 16 bytes. It is read from sysfs. */
 static uint32_t read_cid(uint16_t dev_id, uint8_t *cid)
 {
-	TEEC_Result res;
-	char path[48];
-	char hex[3] = { 0, };
-	int st;
-	int fd;
-	int i;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	char path[48] = { 0 };
+	char hex[3] = { 0 };
+	int st = 0;
+	int fd = 0;
+	int i = 0;
 
 	snprintf(path, sizeof(path),
 		 "/sys/class/mmc_host/mmc%u/mmc%u:0001/cid", dev_id, dev_id);
@@ -275,8 +275,8 @@ static struct rpmb_emu *mem_for_fd(int fd)
 static void dump_blocks(size_t startblk, size_t numblk, uint8_t *ptr,
 			bool to_mmc)
 {
-	char msg[100];
-	size_t i;
+	char msg[100] = { 0 };
+	size_t i = 0;
 
 	for (i = 0; i < numblk; i++) {
 		snprintf(msg, sizeof(msg), "%s MMC block %zu",
@@ -311,9 +311,9 @@ static void hmac_update_frm(hmac_sha256_ctx *ctx, struct rpmb_data_frame *frm)
 static bool is_hmac_valid(struct rpmb_emu *mem, struct rpmb_data_frame *frm,
 		   size_t nfrm)
 {
-	hmac_sha256_ctx ctx;
-	uint8_t mac[32];
-	size_t i;
+	hmac_sha256_ctx ctx = { 0 };
+	uint8_t mac[32] = { 0 };
+	size_t i = 0;
 
 	if (!mem->key_set) {
 		EMSG("Cannot check MAC (key not set)");
@@ -336,8 +336,8 @@ static bool is_hmac_valid(struct rpmb_emu *mem, struct rpmb_data_frame *frm,
 static uint16_t compute_hmac(struct rpmb_emu *mem, struct rpmb_data_frame *frm,
 			     size_t nfrm)
 {
-	hmac_sha256_ctx ctx;
-	size_t i;
+	hmac_sha256_ctx ctx = { 0 };
+	size_t i = 0;
 
 	if (!mem->key_set) {
 		EMSG("Cannot compute MAC (key not set)");
@@ -359,8 +359,8 @@ static uint16_t ioctl_emu_mem_transfer(struct rpmb_emu *mem,
 {
 	size_t start = mem->last_op.address * 256;
 	size_t size = nfrm * 256;
-	size_t i;
-	uint8_t *memptr;
+	size_t i = 0;
+	uint8_t *memptr = NULL;
 
 	if (start > mem->size || start + size > mem->size) {
 		EMSG("Transfer bounds exceeed emulated memory");
@@ -479,9 +479,9 @@ static void ioctl_emu_set_ext_csd(uint8_t *ext_csd)
 /* A crude emulation of the MMC ioctls we need for RPMB */
 static int ioctl_emu(int fd, unsigned long request, ...)
 {
-	struct mmc_ioc_cmd *cmd;
-	struct rpmb_data_frame *frm;
-	uint16_t msg_type;
+	struct mmc_ioc_cmd *cmd = NULL;
+	struct rpmb_data_frame *frm = NULL;
+	uint16_t msg_type = 0;
 	struct rpmb_emu *mem = mem_for_fd(fd);
 	va_list ap;
 
@@ -593,7 +593,7 @@ static void close_mmc_fd(int fd)
  */
 static uint32_t read_ext_csd(int fd, uint8_t *ext_csd)
 {
-	int st;
+	int st = 0;
 	struct mmc_ioc_cmd cmd;
 
 	memset(&cmd, 0, sizeof(cmd));
@@ -614,8 +614,8 @@ static uint32_t rpmb_data_req(int fd, struct rpmb_data_frame *req_frm,
 			      size_t req_nfrm, struct rpmb_data_frame *rsp_frm,
 			      size_t rsp_nfrm)
 {
-	int st;
-	size_t i;
+	int st = 0;
+	size_t i = 0;
 	uint16_t msg_type = ntohs(req_frm->msg_type);
 	struct mmc_ioc_cmd cmd;
 
@@ -719,9 +719,9 @@ static uint32_t rpmb_data_req(int fd, struct rpmb_data_frame *req_frm,
 
 static uint32_t rpmb_get_dev_info(uint16_t dev_id, struct rpmb_dev_info *info)
 {
-	int fd;
-	uint32_t res;
-	uint8_t ext_csd[512];
+	int fd = 0;
+	uint32_t res = 0;
+	uint8_t ext_csd[512] = { 0 };
 
 	res = read_cid(dev_id, info->cid);
 	if (res != TEEC_SUCCESS)
@@ -753,10 +753,10 @@ static uint32_t rpmb_process_request_unlocked(void *req, size_t req_size,
 					      void *rsp, size_t rsp_size)
 {
 	struct rpmb_req *sreq = req;
-	size_t req_nfrm;
-	size_t rsp_nfrm;
-	uint32_t res;
-	int fd;
+	size_t req_nfrm = 0;
+	size_t rsp_nfrm = 0;
+	uint32_t res = 0;
+	int fd = 0;
 
 	if (req_size < sizeof(*sreq))
 		return TEEC_ERROR_BAD_PARAMETERS;
@@ -795,7 +795,7 @@ static uint32_t rpmb_process_request_unlocked(void *req, size_t req_size,
 uint32_t rpmb_process_request(void *req, size_t req_size, void *rsp,
 			      size_t rsp_size)
 {
-	uint32_t res;
+	uint32_t res = 0;
 
 	tee_supp_mutex_lock(&rpmb_mutex);
 	res = rpmb_process_request_unlocked(req, req_size, rsp, rsp_size);

--- a/tee-supplicant/src/rpmb.c
+++ b/tee-supplicant/src/rpmb.c
@@ -311,9 +311,11 @@ static void hmac_update_frm(hmac_sha256_ctx *ctx, struct rpmb_data_frame *frm)
 static bool is_hmac_valid(struct rpmb_emu *mem, struct rpmb_data_frame *frm,
 		   size_t nfrm)
 {
-	hmac_sha256_ctx ctx = { 0 };
 	uint8_t mac[32] = { 0 };
 	size_t i = 0;
+	hmac_sha256_ctx ctx;
+
+	memset(&ctx, 0, sizeof(ctx));
 
 	if (!mem->key_set) {
 		EMSG("Cannot check MAC (key not set)");
@@ -336,8 +338,10 @@ static bool is_hmac_valid(struct rpmb_emu *mem, struct rpmb_data_frame *frm,
 static uint16_t compute_hmac(struct rpmb_emu *mem, struct rpmb_data_frame *frm,
 			     size_t nfrm)
 {
-	hmac_sha256_ctx ctx = { 0 };
 	size_t i = 0;
+	hmac_sha256_ctx ctx;
+
+	memset(&ctx, 0, sizeof(ctx));
 
 	if (!mem->key_set) {
 		EMSG("Cannot compute MAC (key not set)");

--- a/tee-supplicant/src/sha2.c
+++ b/tee-supplicant/src/sha2.c
@@ -167,7 +167,9 @@ static void sha256_transf(sha256_ctx *ctx, const unsigned char *message,
 void sha256(const unsigned char *message, unsigned int len,
 	    unsigned char *digest)
 {
-    sha256_ctx ctx = { 0 };
+    sha256_ctx ctx;
+
+    memset(&ctx, 0, sizeof(ctx));
 
     sha256_init(&ctx);
     sha256_update(&ctx, message, len);

--- a/tee-supplicant/src/sha2.c
+++ b/tee-supplicant/src/sha2.c
@@ -121,12 +121,13 @@ uint32 sha256_k[64] =
 static void sha256_transf(sha256_ctx *ctx, const unsigned char *message,
                           unsigned int block_nb)
 {
-    uint32 w[64];
-    uint32 wv[8];
-    uint32 t1, t2;
-    const unsigned char *sub_block;
-    int i;
-    int j;
+    uint32 w[64] = { 0 };
+    uint32 wv[8] = { 0 };
+    uint32 t1 = 0;
+    uint32 t2 = 0;
+    const unsigned char *sub_block = NULL;
+    int i = 0;
+    int j = 0;
 
     for (i = 0; i < (int) block_nb; i++) {
         sub_block = message + (i << 6);
@@ -163,9 +164,10 @@ static void sha256_transf(sha256_ctx *ctx, const unsigned char *message,
     }
 }
 
-void sha256(const unsigned char *message, unsigned int len, unsigned char *digest)
+void sha256(const unsigned char *message, unsigned int len,
+	    unsigned char *digest)
 {
-    sha256_ctx ctx;
+    sha256_ctx ctx = { 0 };
 
     sha256_init(&ctx);
     sha256_update(&ctx, message, len);
@@ -175,6 +177,7 @@ void sha256(const unsigned char *message, unsigned int len, unsigned char *diges
 void sha256_init(sha256_ctx *ctx)
 {
     int i;
+
     for (i = 0; i < 8; i++) {
         ctx->h[i] = sha256_h0[i];
     }
@@ -186,9 +189,11 @@ void sha256_init(sha256_ctx *ctx)
 void sha256_update(sha256_ctx *ctx, const unsigned char *message,
                    unsigned int len)
 {
-    unsigned int block_nb;
-    unsigned int new_len, rem_len, tmp_len;
-    const unsigned char *shifted_message;
+    unsigned int block_nb = 0;
+    unsigned int new_len = 0;
+    unsigned int rem_len = 0;
+    unsigned int tmp_len = 0;
+    const unsigned char *shifted_message = NULL;
 
     tmp_len = SHA256_BLOCK_SIZE - ctx->len;
     rem_len = len < tmp_len ? len : tmp_len;
@@ -219,10 +224,10 @@ void sha256_update(sha256_ctx *ctx, const unsigned char *message,
 
 void sha256_final(sha256_ctx *ctx, unsigned char *digest)
 {
-    unsigned int block_nb;
-    unsigned int pm_len;
-    unsigned int len_b;
-    int i;
+    unsigned int block_nb = 0;
+    unsigned int pm_len = 0;
+    unsigned int len_b = 0;
+    int i = 0;
 
     block_nb = (1 + ((SHA256_BLOCK_SIZE - 9)
                      < (ctx->len % SHA256_BLOCK_SIZE)));

--- a/tee-supplicant/src/tee_socket.c
+++ b/tee-supplicant/src/tee_socket.c
@@ -172,15 +172,15 @@ static TEEC_Result sock_connect(uint32_t ip_vers, unsigned int protocol,
 				const char *server, uint16_t port, int *ret_fd)
 {
 	TEEC_Result r = TEEC_ERROR_GENERIC;
-	struct addrinfo hints = { 0 };
 	struct addrinfo *res0 = NULL;
 	struct addrinfo *res = NULL;
 	int fd = -1;
 	char port_name[10] = { 0 };
-
-	snprintf(port_name, sizeof(port_name), "%" PRIu16, port);
+	struct addrinfo hints;
 
 	memset(&hints, 0, sizeof(hints));
+
+	snprintf(port_name, sizeof(port_name), "%" PRIu16, port);
 
 	switch (ip_vers) {
 	case TEE_IP_VERSION_DC:
@@ -378,15 +378,20 @@ static void ts_delay_from_millis(uint32_t millis, struct timespec *res)
 static TEEC_Result poll_with_timeout(struct pollfd *pfd, nfds_t nfds,
 				     uint32_t timeout)
 {
-	struct timespec now = { 0 };
-	struct timespec until = { 0 };
+	struct timespec now;
+	struct timespec until;
 	int to = 0;
 	int r = 0;
+
+	memset(&now, 0, sizeof(now));
+	memset(&until, 0, sizeof(until));
 
 	if (timeout == OPTEE_MRC_SOCKET_TIMEOUT_BLOCKING) {
 		to = -1;
 	} else {
-		struct timespec delay = { 0 };
+		struct timespec delay;
+
+		memset(&delay, 0, sizeof(delay));
 
 		ts_delay_from_millis(timeout, &delay);
 
@@ -598,14 +603,15 @@ static TEEC_Result udp_changeaddr(int fd, int family, const char *server,
 				  uint16_t port)
 {
 	TEEC_Result r = TEE_ISOCKET_ERROR_HOSTNAME;
-	struct addrinfo hints = { 0 };
 	struct addrinfo *res0 = NULL;
 	struct addrinfo *res = NULL;
 	char port_name[10] = { 0 };
+	struct addrinfo hints;
+
+	memset(&hints, 0, sizeof(hints));
 
 	snprintf(port_name, sizeof(port_name), "%" PRIu16, port);
 
-	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = family;
 	hints.ai_socktype = SOCK_DGRAM;
 	if (getaddrinfo(server, port_name, &hints, &res0))
@@ -630,10 +636,12 @@ static TEEC_Result tee_socket_ioctl_udp(int fd, uint32_t command,
 					void *buf, size_t *blen)
 {
 	TEEC_Result res = TEEC_ERROR_GENERIC;
-	struct sockaddr_storage sass = { 0 };
+	uint16_t port = 0;
+	struct sockaddr_storage sass;
 	struct sockaddr *sa = (struct sockaddr *)&sass;
 	socklen_t len = sizeof(sass);
-	uint16_t port = 0;
+
+	memset(&sass, 0, sizeof(sass));
 
 	if (getpeername(fd, sa, &len))
 		return TEEC_ERROR_BAD_PARAMETERS;

--- a/tee-supplicant/src/tee_socket.c
+++ b/tee-supplicant/src/tee_socket.c
@@ -80,7 +80,7 @@ static void sock_unlock(void)
 
 static struct sock_instance *sock_instance_find(uint32_t instance_id)
 {
-	struct sock_instance *si;
+	struct sock_instance *si = NULL;
 
 	TAILQ_FOREACH(si, &sock_instances, link) {
 		if (si->id == instance_id)
@@ -91,7 +91,7 @@ static struct sock_instance *sock_instance_find(uint32_t instance_id)
 
 static void *fd_to_handle_ptr(int fd)
 {
-	uintptr_t ptr;
+	uintptr_t ptr = 0;
 
 	assert(fd >= 0);
 	ptr = fd + 1;
@@ -107,7 +107,7 @@ static int handle_ptr_to_fd(void *ptr)
 static int sock_handle_get(uint32_t instance_id, int fd)
 {
 	int handle = -1;
-	struct sock_instance *si;
+	struct sock_instance *si = NULL;
 
 	sock_lock();
 
@@ -129,7 +129,7 @@ out:
 static int sock_handle_to_fd(uint32_t instance_id, uint32_t handle)
 {
 	int fd = -1;
-	struct sock_instance *si;
+	struct sock_instance *si = NULL;
 
 	sock_lock();
 	si = sock_instance_find(instance_id);
@@ -141,7 +141,7 @@ static int sock_handle_to_fd(uint32_t instance_id, uint32_t handle)
 
 static void sock_handle_put(uint32_t instance_id, uint32_t handle)
 {
-	struct sock_instance *si;
+	struct sock_instance *si = NULL;
 
 	sock_lock();
 	si = sock_instance_find(instance_id);
@@ -157,7 +157,7 @@ static bool chk_pt(struct tee_ioctl_param *param, uint32_t type)
 
 static int fd_flags_add(int fd, int flags)
 {
-	int val;
+	int val = 0;
 
 	val = fcntl(fd, F_GETFD, 0);
 	if (val == -1)
@@ -172,11 +172,11 @@ static TEEC_Result sock_connect(uint32_t ip_vers, unsigned int protocol,
 				const char *server, uint16_t port, int *ret_fd)
 {
 	TEEC_Result r = TEEC_ERROR_GENERIC;
-	struct addrinfo hints;
-	struct addrinfo *res0;
-	struct addrinfo *res;
+	struct addrinfo hints = { 0 };
+	struct addrinfo *res0 = NULL;
+	struct addrinfo *res = NULL;
 	int fd = -1;
-	char port_name[10];
+	char port_name[10] = { 0 };
 
 	snprintf(port_name, sizeof(port_name), "%" PRIu16, port);
 
@@ -246,14 +246,14 @@ static TEEC_Result sock_connect(uint32_t ip_vers, unsigned int protocol,
 static TEEC_Result tee_socket_open(size_t num_params,
 				   struct tee_ioctl_param *params)
 {
-	TEEC_Result res;
-	int handle;
-	int fd;
-	uint32_t instance_id;
-	char *server;
-	uint32_t ip_vers;
-	uint16_t port;
-	uint32_t protocol;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	int handle = 0;
+	int fd = 0;
+	uint32_t instance_id = 0;
+	char *server = NULL;
+	uint32_t ip_vers = 0;
+	uint16_t port = 0;
+	uint32_t protocol = 0;
 
 	if (num_params != 4 ||
 	    !chk_pt(params + 0, TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INPUT) ||
@@ -288,9 +288,9 @@ static TEEC_Result tee_socket_open(size_t num_params,
 static TEEC_Result tee_socket_close(size_t num_params,
 				    struct tee_ioctl_param *params)
 {
-	int handle;
-	uint32_t instance_id;
-	int fd;
+	int handle = 0;
+	uint32_t instance_id = 0;
+	int fd = 0;
 
 	if (num_params != 1 ||
 	    !chk_pt(params + 0, TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INPUT))
@@ -322,8 +322,8 @@ static void sock_close_cb(int handle, void *ptr, void *arg)
 static TEEC_Result tee_socket_close_all(size_t num_params,
 					struct tee_ioctl_param *params)
 {
-	uint32_t instance_id;
-	struct sock_instance *si;
+	uint32_t instance_id = 0;
+	struct sock_instance *si = NULL;
 
 	if (num_params != 1 ||
 	    !chk_pt(params + 0, TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INPUT))
@@ -355,7 +355,7 @@ static void ts_add(const struct timespec *a, const struct timespec *b,
 static int ts_diff_to_polltimeout(const struct timespec *a,
 				  const struct timespec *b)
 {
-	struct timespec diff;
+	struct timespec diff = { 0 };
 
 	diff.tv_sec = a->tv_sec - b->tv_sec;
 	diff.tv_nsec = a->tv_nsec - b->tv_nsec;
@@ -378,15 +378,15 @@ static void ts_delay_from_millis(uint32_t millis, struct timespec *res)
 static TEEC_Result poll_with_timeout(struct pollfd *pfd, nfds_t nfds,
 				     uint32_t timeout)
 {
-	struct timespec now;
-	struct timespec until = { 0, 0 }; /* gcc warning */
+	struct timespec now = { 0 };
+	struct timespec until = { 0 };
 	int to = 0;
-	int r;
+	int r = 0;
 
 	if (timeout == OPTEE_MRC_SOCKET_TIMEOUT_BLOCKING) {
 		to = -1;
 	} else {
-		struct timespec delay;
+		struct timespec delay = { 0 };
 
 		ts_delay_from_millis(timeout, &delay);
 
@@ -424,9 +424,9 @@ static TEEC_Result poll_with_timeout(struct pollfd *pfd, nfds_t nfds,
 static TEEC_Result write_with_timeout(int fd, const void *buf, size_t *blen,
 				      uint32_t timeout)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	struct pollfd pfd = { .fd = fd, .events = POLLOUT };
-	ssize_t r;
+	ssize_t r = 0;
 
 	res = poll_with_timeout(&pfd, 1, timeout);
 	if (res != TEEC_SUCCESS)
@@ -445,12 +445,12 @@ static TEEC_Result write_with_timeout(int fd, const void *buf, size_t *blen,
 static TEEC_Result tee_socket_send(size_t num_params,
 				   struct tee_ioctl_param *params)
 {
-	TEEC_Result res;
-	int handle;
-	int fd;
-	uint32_t instance_id;
-	void *buf;
-	size_t bytes;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	int handle = 0;
+	int fd = 0;
+	uint32_t instance_id = 0;
+	void *buf = NULL;
+	size_t bytes = 0;
 
 	if (num_params != 3 ||
 	    !chk_pt(params + 0, TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INPUT) ||
@@ -475,9 +475,9 @@ static TEEC_Result tee_socket_send(size_t num_params,
 static TEEC_Result read_with_timeout(int fd, void *buf, size_t *blen,
 				     uint32_t timeout)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	struct pollfd pfd = { .fd = fd, .events = POLLIN };
-	ssize_t r;
+	ssize_t r = 0;
 
 	res = poll_with_timeout(&pfd, 1, timeout);
 	if (res != TEEC_SUCCESS)
@@ -496,12 +496,12 @@ static TEEC_Result read_with_timeout(int fd, void *buf, size_t *blen,
 static TEEC_Result tee_socket_recv(size_t num_params,
 				   struct tee_ioctl_param *params)
 {
-	TEEC_Result res;
-	int handle;
-	int fd;
-	uint32_t instance_id;
-	void *buf;
-	size_t bytes;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	int handle = 0;
+	int fd = 0;
+	uint32_t instance_id = 0;
+	void *buf = NULL;
+	size_t bytes = 0;
 
 	if (num_params != 3 ||
 	    !chk_pt(params + 0, TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INPUT) ||
@@ -598,10 +598,10 @@ static TEEC_Result udp_changeaddr(int fd, int family, const char *server,
 				  uint16_t port)
 {
 	TEEC_Result r = TEE_ISOCKET_ERROR_HOSTNAME;
-	struct addrinfo hints;
-	struct addrinfo *res0;
-	struct addrinfo *res;
-	char port_name[10];
+	struct addrinfo hints = { 0 };
+	struct addrinfo *res0 = NULL;
+	struct addrinfo *res = NULL;
+	char port_name[10] = { 0 };
 
 	snprintf(port_name, sizeof(port_name), "%" PRIu16, port);
 
@@ -629,11 +629,11 @@ static TEEC_Result udp_changeaddr(int fd, int family, const char *server,
 static TEEC_Result tee_socket_ioctl_udp(int fd, uint32_t command,
 					void *buf, size_t *blen)
 {
-	TEEC_Result res;
-	struct sockaddr_storage sass;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	struct sockaddr_storage sass = { 0 };
 	struct sockaddr *sa = (struct sockaddr *)&sass;
 	socklen_t len = sizeof(sass);
-	uint16_t port;
+	uint16_t port = 0;
 
 	if (getpeername(fd, sa, &len))
 		return TEEC_ERROR_BAD_PARAMETERS;
@@ -666,15 +666,15 @@ static TEEC_Result tee_socket_ioctl_udp(int fd, uint32_t command,
 static TEEC_Result tee_socket_ioctl(size_t num_params,
 				    struct tee_ioctl_param *params)
 {
-	TEEC_Result res;
-	int handle;
-	int fd;
-	uint32_t instance_id;
-	uint32_t command;
-	void *buf;
-	int socktype;
-	socklen_t l;
-	size_t sz;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	int handle = 0;
+	int fd = 0;
+	uint32_t instance_id = 0;
+	uint32_t command = 0;
+	void *buf = NULL;
+	int socktype = 0;
+	socklen_t l = 0;
+	size_t sz = 0;
 
 	if (num_params != 3 ||
 	    !chk_pt(params + 0, TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INPUT) ||

--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -63,7 +63,7 @@ static struct handle_db dir_handle_db =
 static size_t tee_fs_get_absolute_filename(char *file, char *out,
 					   size_t out_size)
 {
-	int s;
+	int s = 0;
 
 	if (!file || !out || (out_size <= strlen(tee_fs_root) + 1))
 		return 0;
@@ -78,7 +78,7 @@ static size_t tee_fs_get_absolute_filename(char *file, char *out,
 
 static int do_mkdir(const char *path, mode_t mode)
 {
-	struct stat st;
+	struct stat st = { 0 };
 
 	if (mkdir(path, mode) != 0 && errno != EEXIST)
 		return -1;
@@ -94,7 +94,7 @@ static int mkpath(const char *path, mode_t mode)
 	int status = 0;
 	char *subpath = strdup(path);
 	char *prev = subpath;
-	char *curr;
+	char *curr = NULL;
 
 	while (status == 0 && (curr = strchr(prev, '/')) != 0) {
 		/*
@@ -116,7 +116,7 @@ static int mkpath(const char *path, mode_t mode)
 
 int tee_supp_fs_init(void)
 {
-	size_t n;
+	size_t n = 0;
 	mode_t mode = 0700;
 
 	n = snprintf(tee_fs_root, sizeof(tee_fs_root), "%s/tee/", TEE_FS_PARENT_PATH);
@@ -131,7 +131,7 @@ int tee_supp_fs_init(void)
 
 static int open_wrapper(const char *fname, int flags)
 {
-	int fd;
+	int fd = 0;
 
 	while (true) {
 		fd = open(fname, flags | O_SYNC, 0600);
@@ -143,9 +143,9 @@ static int open_wrapper(const char *fname, int flags)
 static TEEC_Result ree_fs_new_open(size_t num_params,
 				   struct tee_ioctl_param *params)
 {
-	char abs_filename[PATH_MAX];
-	char *fname;
-	int fd;
+	char abs_filename[PATH_MAX] = { 0 };
+	char *fname = NULL;
+	int fd = 0;
 
 	if (num_params != 3 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -182,11 +182,11 @@ static TEEC_Result ree_fs_new_open(size_t num_params,
 static TEEC_Result ree_fs_new_create(size_t num_params,
 				     struct tee_ioctl_param *params)
 {
-	char abs_filename[PATH_MAX];
-	char abs_dir[PATH_MAX];
-	char *fname;
-	char *d;
-	int fd;
+	char abs_filename[PATH_MAX] = { 0 };
+	char abs_dir[PATH_MAX] = { 0 };
+	char *fname = NULL;
+	char *d = NULL;
+	int fd = 0;
 	const int flags = O_RDWR | O_CREAT | O_TRUNC;
 
 	if (num_params != 3 ||
@@ -261,7 +261,7 @@ out:
 static TEEC_Result ree_fs_new_close(size_t num_params,
 				    struct tee_ioctl_param *params)
 {
-	int fd;
+	int fd = 0;
 
 	if (num_params != 1 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -279,12 +279,12 @@ static TEEC_Result ree_fs_new_close(size_t num_params,
 static TEEC_Result ree_fs_new_read(size_t num_params,
 				   struct tee_ioctl_param *params)
 {
-	uint8_t *buf;
-	size_t len;
-	off_t offs;
-	int fd;
-	ssize_t r;
-	size_t s;
+	uint8_t *buf = NULL;
+	size_t len = 0;
+	off_t offs = 0;
+	int fd = 0;
+	ssize_t r = 0;
+	size_t s = 0;
 
 	if (num_params != 2 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -324,11 +324,11 @@ static TEEC_Result ree_fs_new_read(size_t num_params,
 static TEEC_Result ree_fs_new_write(size_t num_params,
 				    struct tee_ioctl_param *params)
 {
-	uint8_t *buf;
-	size_t len;
-	off_t offs;
-	int fd;
-	ssize_t r;
+	uint8_t *buf = NULL;
+	size_t len = 0;
+	off_t offs = 0;
+	int fd = 0;
+	ssize_t r = 0;
 
 	if (num_params != 2 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -364,8 +364,8 @@ static TEEC_Result ree_fs_new_write(size_t num_params,
 static TEEC_Result ree_fs_new_truncate(size_t num_params,
 				       struct tee_ioctl_param *params)
 {
-	size_t len;
-	int fd;
+	size_t len = 0;
+	int fd = 0;
 
 	if (num_params != 1 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -386,9 +386,9 @@ static TEEC_Result ree_fs_new_truncate(size_t num_params,
 static TEEC_Result ree_fs_new_remove(size_t num_params,
 				     struct tee_ioctl_param *params)
 {
-	char abs_filename[PATH_MAX];
-	char *fname;
-	char *d;
+	char abs_filename[PATH_MAX] = { 0 };
+	char *fname = NULL;
+	char *d = NULL;
 
 	if (num_params != 2 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -428,11 +428,11 @@ static TEEC_Result ree_fs_new_remove(size_t num_params,
 static TEEC_Result ree_fs_new_rename(size_t num_params,
 				     struct tee_ioctl_param *params)
 {
-	char old_abs_filename[PATH_MAX];
-	char new_abs_filename[PATH_MAX];
-	char *old_fname;
-	char *new_fname;
-	bool overwrite;
+	char old_abs_filename[PATH_MAX] = { 0 };
+	char new_abs_filename[PATH_MAX] = { 0 };
+	char *old_fname = NULL;
+	char *new_fname = NULL;
+	bool overwrite = false;
 
 	if (num_params != 3 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -477,11 +477,11 @@ static TEEC_Result ree_fs_new_rename(size_t num_params,
 static TEEC_Result ree_fs_new_opendir(size_t num_params,
 				      struct tee_ioctl_param *params)
 {
-	char abs_filename[PATH_MAX];
-	char *fname;
-	DIR *dir;
-	int handle;
-	struct dirent *dent;
+	char abs_filename[PATH_MAX] = { 0 };
+	char *fname = NULL;
+	DIR *dir = NULL;
+	int handle = 0;
+	struct dirent *dent = NULL;
 	bool empty = true;
 
 	if (num_params != 3 ||
@@ -542,7 +542,7 @@ static TEEC_Result ree_fs_new_opendir(size_t num_params,
 static TEEC_Result ree_fs_new_closedir(size_t num_params,
 				       struct tee_ioctl_param *params)
 {
-	DIR *dir;
+	DIR *dir = NULL;
 
 	if (num_params != 1 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -561,11 +561,11 @@ static TEEC_Result ree_fs_new_closedir(size_t num_params,
 static TEEC_Result ree_fs_new_readdir(size_t num_params,
 				      struct tee_ioctl_param *params)
 {
-	DIR *dir;
-	struct dirent *dirent;
-	char *buf;
-	size_t len;
-	size_t fname_len;
+	DIR *dir = NULL;
+	struct dirent *dirent = NULL;
+	char *buf = NULL;
+	size_t len = 0;
+	size_t fname_len = 0;
 
 	if (num_params != 2 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=

--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -78,7 +78,9 @@ static size_t tee_fs_get_absolute_filename(char *file, char *out,
 
 static int do_mkdir(const char *path, mode_t mode)
 {
-	struct stat st = { 0 };
+	struct stat st;
+
+	memset(&st, 0, sizeof(st));
 
 	if (mkdir(path, mode) != 0 && errno != EEXIST)
 		return -1;

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -97,7 +97,7 @@ static void *thread_main(void *a);
 
 static size_t num_waiters_inc(struct thread_arg *arg)
 {
-	size_t ret;
+	size_t ret = 0;
 
 	tee_supp_mutex_lock(&arg->mutex);
 	arg->num_waiters++;
@@ -110,7 +110,7 @@ static size_t num_waiters_inc(struct thread_arg *arg)
 
 static size_t num_waiters_dec(struct thread_arg *arg)
 {
-	size_t ret;
+	size_t ret = 0;
 
 	tee_supp_mutex_lock(&arg->mutex);
 	assert(arg->num_waiters);
@@ -140,7 +140,7 @@ static int get_value(size_t num_params, struct tee_ioctl_param *params,
 
 static struct tee_shm *find_tshm(int id)
 {
-	struct tee_shm *tshm;
+	struct tee_shm *tshm = NULL;
 
 	tee_supp_mutex_lock(&shm_mutex);
 
@@ -155,8 +155,8 @@ static struct tee_shm *find_tshm(int id)
 
 static struct tee_shm *pop_tshm(int id)
 {
-	struct tee_shm *tshm;
-	struct tee_shm *prev;
+	struct tee_shm *tshm = NULL;
+	struct tee_shm *prev = NULL;
 
 	tee_supp_mutex_lock(&shm_mutex);
 
@@ -197,7 +197,7 @@ static void push_tshm(struct tee_shm *tshm)
 static int get_param(size_t num_params, struct tee_ioctl_param *params,
 		     const uint32_t idx, TEEC_SharedMemory *shm)
 {
-	struct tee_shm *tshm;
+	struct tee_shm *tshm = NULL;
 
 	if (idx >= num_params)
 		return -1;
@@ -255,8 +255,8 @@ static uint32_t load_ta(size_t num_params, struct tee_ioctl_param *params)
 {
 	int ta_found = 0;
 	size_t size = 0;
-	TEEC_UUID uuid;
-	struct tee_ioctl_param_value *val_cmd;
+	TEEC_UUID uuid = { 0 };
+	struct tee_ioctl_param_value *val_cmd = NULL;
 	TEEC_SharedMemory shm_ta;
 
 	memset(&shm_ta, 0, sizeof(shm_ta));
@@ -289,7 +289,7 @@ static uint32_t load_ta(size_t num_params, struct tee_ioctl_param *params)
 static struct tee_shm *alloc_shm(int fd, size_t size)
 {
 	struct tee_ioctl_shm_alloc_data data;
-	struct tee_shm *shm;
+	struct tee_shm *shm = NULL;
 
 	memset(&data, 0, sizeof(data));
 
@@ -320,8 +320,8 @@ static struct tee_shm *alloc_shm(int fd, size_t size)
 static struct tee_shm *register_local_shm(int fd, size_t size)
 {
 	struct tee_ioctl_shm_register_data data;
-	struct tee_shm *shm;
-	void *buf;
+	struct tee_shm *shm = NULL;
+	void *buf = NULL;
 
 	memset(&data, 0, sizeof(data));
 
@@ -355,8 +355,8 @@ static struct tee_shm *register_local_shm(int fd, size_t size)
 static uint32_t process_alloc(struct thread_arg *arg, size_t num_params,
 			      struct tee_ioctl_param *params)
 {
-	struct tee_ioctl_param_value *val;
-	struct tee_shm *shm;
+	struct tee_ioctl_param_value *val = NULL;
+	struct tee_shm *shm = NULL;
 
 	if (num_params != 1 || get_value(num_params, params, 0, &val))
 		return TEEC_ERROR_BAD_PARAMETERS;
@@ -378,9 +378,9 @@ static uint32_t process_alloc(struct thread_arg *arg, size_t num_params,
 
 static uint32_t process_free(size_t num_params, struct tee_ioctl_param *params)
 {
-	struct tee_ioctl_param_value *val;
-	struct tee_shm *shm;
-	int id;
+	struct tee_ioctl_param_value *val = NULL;
+	struct tee_shm *shm = NULL;
+	int id = 0;
 
 	if (num_params != 1 || get_value(num_params, params, 0, &val))
 		return TEEC_ERROR_BAD_PARAMETERS;
@@ -415,8 +415,8 @@ static uint32_t process_free(size_t num_params, struct tee_ioctl_param *params)
 
 static int open_dev(const char *devname, uint32_t *gen_caps)
 {
-	struct tee_ioctl_version_data vers;
-	int fd;
+	struct tee_ioctl_version_data vers = { 0 };
+	int fd = 0;
 
 	fd = open(devname, O_RDWR);
 	if (fd < 0)
@@ -442,9 +442,9 @@ err:
 
 static int get_dev_fd(uint32_t *gen_caps)
 {
-	int fd;
-	char name[PATH_MAX];
-	size_t n;
+	int fd = 0;
+	char name[PATH_MAX] = { 0 };
+	size_t n = 0;
 
 	for (n = 0; n < MAX_DEV_SEQ; n++) {
 		snprintf(name, sizeof(name), "/dev/teepriv%zu", n);
@@ -465,8 +465,8 @@ static int usage(int status)
 
 static uint32_t process_rpmb(size_t num_params, struct tee_ioctl_param *params)
 {
-	TEEC_SharedMemory req;
-	TEEC_SharedMemory rsp;
+	TEEC_SharedMemory req = { 0 };
+	TEEC_SharedMemory rsp = { 0 };
 
 	if (get_param(num_params, params, 0, &req) ||
 	    get_param(num_params, params, 1, &rsp))
@@ -477,7 +477,7 @@ static uint32_t process_rpmb(size_t num_params, struct tee_ioctl_param *params)
 
 static bool read_request(int fd, union tee_rpc_invoke *request)
 {
-	struct tee_ioctl_buf_data data;
+	struct tee_ioctl_buf_data data = { 0 };
 
 	data.buf_ptr = (uintptr_t)request;
 	data.buf_len = sizeof(*request);
@@ -490,7 +490,7 @@ static bool read_request(int fd, union tee_rpc_invoke *request)
 
 static bool write_response(int fd, union tee_rpc_invoke *request)
 {
-	struct tee_ioctl_buf_data data;
+	struct tee_ioctl_buf_data data = { 0 };
 
 	data.buf_ptr = (uintptr_t)&request->send;
 	data.buf_len = sizeof(struct tee_iocl_supp_send_arg) +
@@ -507,8 +507,8 @@ static bool find_params(union tee_rpc_invoke *request, uint32_t *func,
 			size_t *num_params, struct tee_ioctl_param **params,
 			size_t *num_meta)
 {
-	struct tee_ioctl_param *p;
-	size_t n;
+	struct tee_ioctl_param *p = NULL;
+	size_t n = 0;
 
 	p = (struct tee_ioctl_param *)(&request->recv + 1);
 
@@ -535,8 +535,8 @@ static bool find_params(union tee_rpc_invoke *request, uint32_t *func,
 
 static bool spawn_thread(struct thread_arg *arg)
 {
-	pthread_t tid;
-	int e;
+	pthread_t tid = { 0 };
+	int e = 0;
 
 	DMSG("Spawning a new thread");
 
@@ -562,12 +562,12 @@ static bool spawn_thread(struct thread_arg *arg)
 
 static bool process_one_request(struct thread_arg *arg)
 {
-	union tee_rpc_invoke request;
-	size_t num_params;
-	size_t num_meta;
-	struct tee_ioctl_param *params;
-	uint32_t func;
-	uint32_t ret;
+	union tee_rpc_invoke request = { 0 };
+	size_t num_params = 0;
+	size_t num_meta = 0;
+	struct tee_ioctl_param *params = NULL;
+	uint32_t func = 0;
+	uint32_t ret = 0;
 
 	DMSG("looping");
 	memset(&request, 0, sizeof(request));
@@ -644,8 +644,8 @@ int main(int argc, char *argv[])
 	struct thread_arg arg = { .fd = -1 };
 	bool daemonize = false;
 	char *dev = NULL;
-	int e;
-	int i;
+	int e = 0;
+	int i = 0;
 
 	e = pthread_mutex_init(&arg.mutex, NULL);
 	if (e) {
@@ -726,8 +726,8 @@ bool tee_supp_param_is_value(struct tee_ioctl_param *param)
 
 void *tee_supp_param_to_va(struct tee_ioctl_param *param)
 {
-	struct tee_shm *tshm;
-	size_t end_offs;
+	struct tee_shm *tshm = NULL;
+	size_t end_offs = 0;
 
 	if (!tee_supp_param_is_memref(param))
 		return NULL;

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -255,10 +255,11 @@ static uint32_t load_ta(size_t num_params, struct tee_ioctl_param *params)
 {
 	int ta_found = 0;
 	size_t size = 0;
-	TEEC_UUID uuid = { 0 };
 	struct tee_ioctl_param_value *val_cmd = NULL;
+	TEEC_UUID uuid;
 	TEEC_SharedMemory shm_ta;
 
+	memset(&uuid, 0, sizeof(uuid));
 	memset(&shm_ta, 0, sizeof(shm_ta));
 
 	if (num_params != 2 || get_value(num_params, params, 0, &val_cmd) ||
@@ -288,8 +289,8 @@ static uint32_t load_ta(size_t num_params, struct tee_ioctl_param *params)
 
 static struct tee_shm *alloc_shm(int fd, size_t size)
 {
-	struct tee_ioctl_shm_alloc_data data;
 	struct tee_shm *shm = NULL;
+	struct tee_ioctl_shm_alloc_data data;
 
 	memset(&data, 0, sizeof(data));
 
@@ -319,9 +320,9 @@ static struct tee_shm *alloc_shm(int fd, size_t size)
 
 static struct tee_shm *register_local_shm(int fd, size_t size)
 {
-	struct tee_ioctl_shm_register_data data;
 	struct tee_shm *shm = NULL;
 	void *buf = NULL;
+	struct tee_ioctl_shm_register_data data;
 
 	memset(&data, 0, sizeof(data));
 
@@ -415,8 +416,10 @@ static uint32_t process_free(size_t num_params, struct tee_ioctl_param *params)
 
 static int open_dev(const char *devname, uint32_t *gen_caps)
 {
-	struct tee_ioctl_version_data vers = { 0 };
 	int fd = 0;
+	struct tee_ioctl_version_data vers;
+
+	memset(&vers, 0, sizeof(vers));
 
 	fd = open(devname, O_RDWR);
 	if (fd < 0)
@@ -465,8 +468,11 @@ static int usage(int status)
 
 static uint32_t process_rpmb(size_t num_params, struct tee_ioctl_param *params)
 {
-	TEEC_SharedMemory req = { 0 };
-	TEEC_SharedMemory rsp = { 0 };
+	TEEC_SharedMemory req;
+	TEEC_SharedMemory rsp;
+
+	memset(&req, 0, sizeof(req));
+	memset(&rsp, 0, sizeof(rsp));
 
 	if (get_param(num_params, params, 0, &req) ||
 	    get_param(num_params, params, 1, &rsp))
@@ -477,7 +483,9 @@ static uint32_t process_rpmb(size_t num_params, struct tee_ioctl_param *params)
 
 static bool read_request(int fd, union tee_rpc_invoke *request)
 {
-	struct tee_ioctl_buf_data data = { 0 };
+	struct tee_ioctl_buf_data data;
+
+	memset(&data, 0, sizeof(data));
 
 	data.buf_ptr = (uintptr_t)request;
 	data.buf_len = sizeof(*request);
@@ -490,7 +498,9 @@ static bool read_request(int fd, union tee_rpc_invoke *request)
 
 static bool write_response(int fd, union tee_rpc_invoke *request)
 {
-	struct tee_ioctl_buf_data data = { 0 };
+	struct tee_ioctl_buf_data data;
+
+	memset(&data, 0, sizeof(data));
 
 	data.buf_ptr = (uintptr_t)&request->send;
 	data.buf_len = sizeof(struct tee_iocl_supp_send_arg) +
@@ -535,8 +545,10 @@ static bool find_params(union tee_rpc_invoke *request, uint32_t *func,
 
 static bool spawn_thread(struct thread_arg *arg)
 {
-	pthread_t tid = { 0 };
 	int e = 0;
+	pthread_t tid;
+
+	memset(&tid, 0, sizeof(tid));
 
 	DMSG("Spawning a new thread");
 
@@ -562,12 +574,14 @@ static bool spawn_thread(struct thread_arg *arg)
 
 static bool process_one_request(struct thread_arg *arg)
 {
-	union tee_rpc_invoke request = { 0 };
 	size_t num_params = 0;
 	size_t num_meta = 0;
 	struct tee_ioctl_param *params = NULL;
 	uint32_t func = 0;
 	uint32_t ret = 0;
+	union tee_rpc_invoke request;
+
+	memset(&request, 0, sizeof(request));
 
 	DMSG("looping");
 	memset(&request, 0, sizeof(request));

--- a/tee-supplicant/src/teec_ta_load.c
+++ b/tee-supplicant/src/teec_ta_load.c
@@ -81,11 +81,11 @@ static int try_load_secure_module(const char* prefix,
 				  const TEEC_UUID *destination, void *ta,
 				  size_t *ta_size)
 {
-	char fname[PATH_MAX];
+	char fname[PATH_MAX] = { 0 };
 	FILE *file = NULL;
 	bool first_try = true;
-	size_t s;
-	int n;
+	size_t s = 0;
+	int n = 0;
 
 	if (!ta_size || !destination) {
 		printf("wrong inparameter to TEECI_LoadSecureModule\n");
@@ -169,7 +169,7 @@ int TEECI_LoadSecureModule(const char* dev_path,
 			   size_t *ta_size)
 {
 #ifdef TEEC_TEST_LOAD_PATH
-	int res;
+	int res = 0;
 
 	res = try_load_secure_module(TEEC_TEST_LOAD_PATH,
 				     dev_path, destination, ta, ta_size);


### PR DESCRIPTION
A first commit to fix a build issue reported by Buildroot team.
A second commit to initialize (almost) all functions local variables. May prevent build errors in the future.