### PR TITLE
cmake: support BUILD_STATIC_LIBS/BUILD_SHARED_LIBS

### DIFF
--- a/libteec/CMakeLists.txt
+++ b/libteec/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 ################################################################################
 # Built library
 ################################################################################
-add_library (teec SHARED ${SRC})
+add_library (teec ${SRC})
 
 set_target_properties (teec PROPERTIES
 	VERSION ${PROJECT_VERSION}
@@ -71,4 +71,5 @@ target_link_libraries (teec
 ################################################################################
 # FIXME: This should in someway harmonize with CFG_TEE_CLIENT_LOAD_PATH
 # FIXME: Should we change this to /usr/local/lib?
-install (TARGETS teec DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install (TARGETS teec LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+                      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -85,4 +85,4 @@ target_link_libraries (${PROJECT_NAME}
 ################################################################################
 # Install targets
 ################################################################################
-install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_SBINDIR})
+install (TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_SBINDIR})


### PR DESCRIPTION
CMake variables BUILD_STATIC_LIBS and BUILD_SHARED_LIBS
set constraints on libraries and executable linkage.

With this change OP-TEE client CMake script builds and installs the
embedded files with the expected linkage configuration.

Reported-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>