### PR TITLE
explicitly initialize local variables

### DIFF
--- a/libteec/src/teec_benchmark.c
+++ b/libteec/src/teec_benchmark.c
@@ -63,8 +63,8 @@ static inline uint64_t read_ccounter(void)
 
 static TEEC_Result benchmark_pta_open(void)
 {
-	TEEC_Result res;
-	uint32_t ret_orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t ret_orig = 0;
 
 	res = TEEC_InitializeContext(NULL, &bench_ctx);
 	if (res != TEEC_SUCCESS)
@@ -90,9 +90,11 @@ static void benchmark_pta_close(void)
 static TEEC_Result benchmark_get_bench_buf_paddr(uint64_t *paddr_ts_buf,
 				uint64_t *size)
 {
-	TEEC_Result res;
-	TEEC_Operation op = { 0 };
-	uint32_t ret_orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t ret_orig = 0;
+	TEEC_Operation op;
+
+	memset(&op, 0, sizeof(op));
 
 	res = benchmark_pta_open();
 	if (res != TEEC_SUCCESS)
@@ -116,10 +118,10 @@ static TEEC_Result benchmark_get_bench_buf_paddr(uint64_t *paddr_ts_buf,
 
 static void *mmap_paddr(intptr_t paddr, uint64_t size)
 {
-	int   devmem;
-	off_t offset;
-	off_t page_addr;
-	intptr_t *hw_addr;
+	int devmem = 0;
+	off_t offset = 0;
+	off_t page_addr = 0;
+	intptr_t *hw_addr = NULL;
 
 	devmem = open("/dev/mem", O_RDWR);
 	if (!devmem)
@@ -163,14 +165,18 @@ static bool benchmark_check_mode(void)
 /* Adding timestamp to buffer */
 void bm_timestamp(void)
 {
+	struct tee_ts_cpu_buf *cpu_buf = NULL;
+	uint64_t ts_i = 0;
+	void *ret_addr = NULL;
+	uint32_t cur_cpu = 0;
+	int ret = 0;
 	cpu_set_t cpu_set_old;
 	cpu_set_t cpu_set_tmp;
-	struct tee_ts_cpu_buf *cpu_buf;
 	struct tee_time_st ts_data;
-	uint64_t ts_i;
-	void *ret_addr;
-	uint32_t cur_cpu;
-	int ret;
+
+	memset(&cpu_set_old, 0, sizeof(cpu_set_old));
+	memset(&cpu_set_tmp, 0, sizeof(cpu_set_tmp));
+	memset(&ts_data, 0, sizeof(ts_data));
 
 	if (pthread_mutex_trylock(&teec_bench_mu))
 		return;

--- a/libteec/src/teec_trace.c
+++ b/libteec/src/teec_trace.c
@@ -51,8 +51,7 @@
 #ifdef TEEC_LOG_FILE
 static void log_to_file(const char *buffer)
 {
-	FILE *log_file;
-	log_file = fopen(TEEC_LOG_FILE, "a");
+	FILE *log_file = fopen(TEEC_LOG_FILE, "a");
 
 	if (log_file != NULL) {
 		fprintf(log_file, "%s", buffer);
@@ -103,7 +102,7 @@ void dump_buffer(const char *bname, const uint8_t *buffer, size_t blen)
 	fprintf(stderr, "#### %s\n", bname);
 
 	while (blen > 0) {
-		size_t n;
+		size_t n = 0;
 
 		for (n = 0; n < 16; n++) {
 			if (n < blen)

--- a/tee-supplicant/src/gprof.c
+++ b/tee-supplicant/src/gprof.c
@@ -44,15 +44,15 @@
 TEEC_Result gprof_process(size_t num_params, struct tee_ioctl_param *params)
 {
 	char vers[5] = "";
-	char path[255];
-	size_t bufsize;
-	TEEC_UUID *u;
+	char path[255] = { 0 };
+	size_t bufsize = 0;
+	TEEC_UUID *u = NULL;
 	int fd = -1;
-	void *buf;
-	int flags;
-	int id;
-	int st;
-	int n;
+	void *buf = NULL;
+	int flags = 0;
+	int id = 0;
+	int st = 0;
+	int n = 0;
 
 	if (num_params != 3 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=

--- a/tee-supplicant/src/handle.c
+++ b/tee-supplicant/src/handle.c
@@ -67,10 +67,10 @@ void handle_db_destroy(struct handle_db *db)
 
 int handle_get(struct handle_db *db, void *ptr)
 {
-	size_t n;
-	void *p;
-	size_t new_max_ptrs;
-	int ret;
+	size_t n = 0;
+	void *p = NULL;
+	size_t new_max_ptrs = 0;
+	int ret = 0;
 
 	if (!db || !ptr)
 		return -1;
@@ -112,7 +112,7 @@ out:
 
 void *handle_put(struct handle_db *db, int handle)
 {
-	void *p;
+	void *p = NULL;
 
 	if (!db || handle < 0)
 		return NULL;
@@ -134,7 +134,7 @@ out:
 
 void *handle_lookup(struct handle_db *db, int handle)
 {
-	void *p;
+	void *p = NULL;
 
 	if (!db || handle < 0)
 		return NULL;
@@ -157,7 +157,7 @@ void handle_foreach_put(struct handle_db *db,
 			void (*cb)(int handle, void *ptr, void *arg),
 			void *arg)
 {
-	size_t n;
+	size_t n = 0;
 
 	if (!db || !cb)
 		return;

--- a/tee-supplicant/src/hmac_sha2.c
+++ b/tee-supplicant/src/hmac_sha2.c
@@ -43,12 +43,11 @@
 void hmac_sha256_init(hmac_sha256_ctx *ctx, const unsigned char *key,
                       unsigned int key_size)
 {
-    unsigned int fill;
-    unsigned int num;
-
-    const unsigned char *key_used;
-    unsigned char key_temp[SHA256_DIGEST_SIZE];
-    int i;
+    unsigned int fill = 0;
+    unsigned int num = 0;
+    const unsigned char *key_used = NULL;
+    unsigned char key_temp[SHA256_DIGEST_SIZE] = { 0 };
+    int i = 0;
 
     if (key_size == SHA256_BLOCK_SIZE) {
         key_used = key;
@@ -104,8 +103,8 @@ void hmac_sha256_update(hmac_sha256_ctx *ctx, const unsigned char *message,
 void hmac_sha256_final(hmac_sha256_ctx *ctx, unsigned char *mac,
                        unsigned int mac_size)
 {
-    unsigned char digest_inside[SHA256_DIGEST_SIZE];
-    unsigned char mac_temp[SHA256_DIGEST_SIZE];
+    unsigned char digest_inside[SHA256_DIGEST_SIZE] = { 0 };
+    unsigned char mac_temp[SHA256_DIGEST_SIZE] = { 0 };
 
     sha256_final(&ctx->ctx_inside, digest_inside);
     sha256_update(&ctx->ctx_outside, digest_inside, SHA256_DIGEST_SIZE);
@@ -118,6 +117,8 @@ void hmac_sha256(const unsigned char *key, unsigned int key_size,
           unsigned char *mac, unsigned mac_size)
 {
     hmac_sha256_ctx ctx;
+
+    memset(&ctx, 0, sizeof(ctx));
 
     hmac_sha256_init(&ctx, key, key_size);
     hmac_sha256_update(&ctx, message, message_len);

--- a/tee-supplicant/src/rpmb.c
+++ b/tee-supplicant/src/rpmb.c
@@ -150,7 +150,7 @@ static int mmc_rpmb_fd(uint16_t dev_id)
 {
 	static int id;
 	static int fd = -1;
-	char path[PATH_MAX];
+	char path[PATH_MAX] = { 0 };
 
 	if (fd < 0) {
 #ifdef __ANDROID__
@@ -175,8 +175,8 @@ static int mmc_rpmb_fd(uint16_t dev_id)
 /* Open eMMC device dev_id */
 static int mmc_fd(uint16_t dev_id)
 {
-	int fd;
-	char path[PATH_MAX];
+	int fd = 0;
+	char path[PATH_MAX] = { 0 };
 
 #ifdef __ANDROID__
 	snprintf(path, sizeof(path), "/dev/block/mmcblk%u", dev_id);
@@ -198,12 +198,12 @@ static void close_mmc_fd(int fd)
 /* Device Identification (CID) register is 16 bytes. It is read from sysfs. */
 static uint32_t read_cid(uint16_t dev_id, uint8_t *cid)
 {
-	TEEC_Result res;
-	char path[48];
-	char hex[3] = { 0, };
-	int st;
-	int fd;
-	int i;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	char path[48] = { 0 };
+	char hex[3] = { 0 };
+	int st = 0;
+	int fd = 0;
+	int i = 0;
 
 	snprintf(path, sizeof(path),
 		 "/sys/class/mmc_host/mmc%u/mmc%u:0001/cid", dev_id, dev_id);
@@ -275,8 +275,8 @@ static struct rpmb_emu *mem_for_fd(int fd)
 static void dump_blocks(size_t startblk, size_t numblk, uint8_t *ptr,
 			bool to_mmc)
 {
-	char msg[100];
-	size_t i;
+	char msg[100] = { 0 };
+	size_t i = 0;
 
 	for (i = 0; i < numblk; i++) {
 		snprintf(msg, sizeof(msg), "%s MMC block %zu",
@@ -311,9 +311,11 @@ static void hmac_update_frm(hmac_sha256_ctx *ctx, struct rpmb_data_frame *frm)
 static bool is_hmac_valid(struct rpmb_emu *mem, struct rpmb_data_frame *frm,
 		   size_t nfrm)
 {
+	uint8_t mac[32] = { 0 };
+	size_t i = 0;
 	hmac_sha256_ctx ctx;
-	uint8_t mac[32];
-	size_t i;
+
+	memset(&ctx, 0, sizeof(ctx));
 
 	if (!mem->key_set) {
 		EMSG("Cannot check MAC (key not set)");
@@ -336,8 +338,10 @@ static bool is_hmac_valid(struct rpmb_emu *mem, struct rpmb_data_frame *frm,
 static uint16_t compute_hmac(struct rpmb_emu *mem, struct rpmb_data_frame *frm,
 			     size_t nfrm)
 {
+	size_t i = 0;
 	hmac_sha256_ctx ctx;
-	size_t i;
+
+	memset(&ctx, 0, sizeof(ctx));
 
 	if (!mem->key_set) {
 		EMSG("Cannot compute MAC (key not set)");
@@ -359,8 +363,8 @@ static uint16_t ioctl_emu_mem_transfer(struct rpmb_emu *mem,
 {
 	size_t start = mem->last_op.address * 256;
 	size_t size = nfrm * 256;
-	size_t i;
-	uint8_t *memptr;
+	size_t i = 0;
+	uint8_t *memptr = NULL;
 
 	if (start > mem->size || start + size > mem->size) {
 		EMSG("Transfer bounds exceeed emulated memory");
@@ -479,9 +483,9 @@ static void ioctl_emu_set_ext_csd(uint8_t *ext_csd)
 /* A crude emulation of the MMC ioctls we need for RPMB */
 static int ioctl_emu(int fd, unsigned long request, ...)
 {
-	struct mmc_ioc_cmd *cmd;
-	struct rpmb_data_frame *frm;
-	uint16_t msg_type;
+	struct mmc_ioc_cmd *cmd = NULL;
+	struct rpmb_data_frame *frm = NULL;
+	uint16_t msg_type = 0;
 	struct rpmb_emu *mem = mem_for_fd(fd);
 	va_list ap;
 
@@ -593,7 +597,7 @@ static void close_mmc_fd(int fd)
  */
 static uint32_t read_ext_csd(int fd, uint8_t *ext_csd)
 {
-	int st;
+	int st = 0;
 	struct mmc_ioc_cmd cmd;
 
 	memset(&cmd, 0, sizeof(cmd));
@@ -614,8 +618,8 @@ static uint32_t rpmb_data_req(int fd, struct rpmb_data_frame *req_frm,
 			      size_t req_nfrm, struct rpmb_data_frame *rsp_frm,
 			      size_t rsp_nfrm)
 {
-	int st;
-	size_t i;
+	int st = 0;
+	size_t i = 0;
 	uint16_t msg_type = ntohs(req_frm->msg_type);
 	struct mmc_ioc_cmd cmd;
 
@@ -719,9 +723,9 @@ static uint32_t rpmb_data_req(int fd, struct rpmb_data_frame *req_frm,
 
 static uint32_t rpmb_get_dev_info(uint16_t dev_id, struct rpmb_dev_info *info)
 {
-	int fd;
-	uint32_t res;
-	uint8_t ext_csd[512];
+	int fd = 0;
+	uint32_t res = 0;
+	uint8_t ext_csd[512] = { 0 };
 
 	res = read_cid(dev_id, info->cid);
 	if (res != TEEC_SUCCESS)
@@ -753,10 +757,10 @@ static uint32_t rpmb_process_request_unlocked(void *req, size_t req_size,
 					      void *rsp, size_t rsp_size)
 {
 	struct rpmb_req *sreq = req;
-	size_t req_nfrm;
-	size_t rsp_nfrm;
-	uint32_t res;
-	int fd;
+	size_t req_nfrm = 0;
+	size_t rsp_nfrm = 0;
+	uint32_t res = 0;
+	int fd = 0;
 
 	if (req_size < sizeof(*sreq))
 		return TEEC_ERROR_BAD_PARAMETERS;
@@ -795,7 +799,7 @@ static uint32_t rpmb_process_request_unlocked(void *req, size_t req_size,
 uint32_t rpmb_process_request(void *req, size_t req_size, void *rsp,
 			      size_t rsp_size)
 {
-	uint32_t res;
+	uint32_t res = 0;
 
 	tee_supp_mutex_lock(&rpmb_mutex);
 	res = rpmb_process_request_unlocked(req, req_size, rsp, rsp_size);

--- a/tee-supplicant/src/sha2.c
+++ b/tee-supplicant/src/sha2.c
@@ -121,12 +121,13 @@ uint32 sha256_k[64] =
 static void sha256_transf(sha256_ctx *ctx, const unsigned char *message,
                           unsigned int block_nb)
 {
-    uint32 w[64];
-    uint32 wv[8];
-    uint32 t1, t2;
-    const unsigned char *sub_block;
-    int i;
-    int j;
+    uint32 w[64] = { 0 };
+    uint32 wv[8] = { 0 };
+    uint32 t1 = 0;
+    uint32 t2 = 0;
+    const unsigned char *sub_block = NULL;
+    int i = 0;
+    int j = 0;
 
     for (i = 0; i < (int) block_nb; i++) {
         sub_block = message + (i << 6);
@@ -163,9 +164,12 @@ static void sha256_transf(sha256_ctx *ctx, const unsigned char *message,
     }
 }
 
-void sha256(const unsigned char *message, unsigned int len, unsigned char *digest)
+void sha256(const unsigned char *message, unsigned int len,
+	    unsigned char *digest)
 {
     sha256_ctx ctx;
+
+    memset(&ctx, 0, sizeof(ctx));
 
     sha256_init(&ctx);
     sha256_update(&ctx, message, len);
@@ -174,7 +178,8 @@ void sha256(const unsigned char *message, unsigned int len, unsigned char *diges
 
 void sha256_init(sha256_ctx *ctx)
 {
-    int i;
+    int i = 0;
+
     for (i = 0; i < 8; i++) {
         ctx->h[i] = sha256_h0[i];
     }
@@ -186,9 +191,11 @@ void sha256_init(sha256_ctx *ctx)
 void sha256_update(sha256_ctx *ctx, const unsigned char *message,
                    unsigned int len)
 {
-    unsigned int block_nb;
-    unsigned int new_len, rem_len, tmp_len;
-    const unsigned char *shifted_message;
+    unsigned int block_nb = 0;
+    unsigned int new_len = 0;
+    unsigned int rem_len = 0;
+    unsigned int tmp_len = 0;
+    const unsigned char *shifted_message = NULL;
 
     tmp_len = SHA256_BLOCK_SIZE - ctx->len;
     rem_len = len < tmp_len ? len : tmp_len;
@@ -219,10 +226,10 @@ void sha256_update(sha256_ctx *ctx, const unsigned char *message,
 
 void sha256_final(sha256_ctx *ctx, unsigned char *digest)
 {
-    unsigned int block_nb;
-    unsigned int pm_len;
-    unsigned int len_b;
-    int i;
+    unsigned int block_nb = 0;
+    unsigned int pm_len = 0;
+    unsigned int len_b = 0;
+    int i = 0;
 
     block_nb = (1 + ((SHA256_BLOCK_SIZE - 9)
                      < (ctx->len % SHA256_BLOCK_SIZE)));

--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -63,7 +63,7 @@ static struct handle_db dir_handle_db =
 static size_t tee_fs_get_absolute_filename(char *file, char *out,
 					   size_t out_size)
 {
-	int s;
+	int s = 0;
 
 	if (!file || !out || (out_size <= strlen(tee_fs_root) + 1))
 		return 0;
@@ -80,6 +80,8 @@ static int do_mkdir(const char *path, mode_t mode)
 {
 	struct stat st;
 
+	memset(&st, 0, sizeof(st));
+
 	if (mkdir(path, mode) != 0 && errno != EEXIST)
 		return -1;
 
@@ -94,7 +96,7 @@ static int mkpath(const char *path, mode_t mode)
 	int status = 0;
 	char *subpath = strdup(path);
 	char *prev = subpath;
-	char *curr;
+	char *curr = NULL;
 
 	while (status == 0 && (curr = strchr(prev, '/')) != 0) {
 		/*
@@ -116,7 +118,7 @@ static int mkpath(const char *path, mode_t mode)
 
 int tee_supp_fs_init(void)
 {
-	size_t n;
+	size_t n = 0;
 	mode_t mode = 0700;
 
 	n = snprintf(tee_fs_root, sizeof(tee_fs_root), "%s/tee/", TEE_FS_PARENT_PATH);
@@ -131,7 +133,7 @@ int tee_supp_fs_init(void)
 
 static int open_wrapper(const char *fname, int flags)
 {
-	int fd;
+	int fd = 0;
 
 	while (true) {
 		fd = open(fname, flags | O_SYNC, 0600);
@@ -143,9 +145,9 @@ static int open_wrapper(const char *fname, int flags)
 static TEEC_Result ree_fs_new_open(size_t num_params,
 				   struct tee_ioctl_param *params)
 {
-	char abs_filename[PATH_MAX];
-	char *fname;
-	int fd;
+	char abs_filename[PATH_MAX] = { 0 };
+	char *fname = NULL;
+	int fd = 0;
 
 	if (num_params != 3 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -182,11 +184,11 @@ static TEEC_Result ree_fs_new_open(size_t num_params,
 static TEEC_Result ree_fs_new_create(size_t num_params,
 				     struct tee_ioctl_param *params)
 {
-	char abs_filename[PATH_MAX];
-	char abs_dir[PATH_MAX];
-	char *fname;
-	char *d;
-	int fd;
+	char abs_filename[PATH_MAX] = { 0 };
+	char abs_dir[PATH_MAX] = { 0 };
+	char *fname = NULL;
+	char *d = NULL;
+	int fd = 0;
 	const int flags = O_RDWR | O_CREAT | O_TRUNC;
 
 	if (num_params != 3 ||
@@ -261,7 +263,7 @@ out:
 static TEEC_Result ree_fs_new_close(size_t num_params,
 				    struct tee_ioctl_param *params)
 {
-	int fd;
+	int fd = 0;
 
 	if (num_params != 1 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -279,12 +281,12 @@ static TEEC_Result ree_fs_new_close(size_t num_params,
 static TEEC_Result ree_fs_new_read(size_t num_params,
 				   struct tee_ioctl_param *params)
 {
-	uint8_t *buf;
-	size_t len;
-	off_t offs;
-	int fd;
-	ssize_t r;
-	size_t s;
+	uint8_t *buf = NULL;
+	size_t len = 0;
+	off_t offs = 0;
+	int fd = 0;
+	ssize_t r = 0;
+	size_t s = 0;
 
 	if (num_params != 2 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -324,11 +326,11 @@ static TEEC_Result ree_fs_new_read(size_t num_params,
 static TEEC_Result ree_fs_new_write(size_t num_params,
 				    struct tee_ioctl_param *params)
 {
-	uint8_t *buf;
-	size_t len;
-	off_t offs;
-	int fd;
-	ssize_t r;
+	uint8_t *buf = NULL;
+	size_t len = 0;
+	off_t offs = 0;
+	int fd = 0;
+	ssize_t r = 0;
 
 	if (num_params != 2 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -364,8 +366,8 @@ static TEEC_Result ree_fs_new_write(size_t num_params,
 static TEEC_Result ree_fs_new_truncate(size_t num_params,
 				       struct tee_ioctl_param *params)
 {
-	size_t len;
-	int fd;
+	size_t len = 0;
+	int fd = 0;
 
 	if (num_params != 1 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -386,9 +388,9 @@ static TEEC_Result ree_fs_new_truncate(size_t num_params,
 static TEEC_Result ree_fs_new_remove(size_t num_params,
 				     struct tee_ioctl_param *params)
 {
-	char abs_filename[PATH_MAX];
-	char *fname;
-	char *d;
+	char abs_filename[PATH_MAX] = { 0 };
+	char *fname = NULL;
+	char *d = NULL;
 
 	if (num_params != 2 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -428,11 +430,11 @@ static TEEC_Result ree_fs_new_remove(size_t num_params,
 static TEEC_Result ree_fs_new_rename(size_t num_params,
 				     struct tee_ioctl_param *params)
 {
-	char old_abs_filename[PATH_MAX];
-	char new_abs_filename[PATH_MAX];
-	char *old_fname;
-	char *new_fname;
-	bool overwrite;
+	char old_abs_filename[PATH_MAX] = { 0 };
+	char new_abs_filename[PATH_MAX] = { 0 };
+	char *old_fname = NULL;
+	char *new_fname = NULL;
+	bool overwrite = false;
 
 	if (num_params != 3 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -477,11 +479,11 @@ static TEEC_Result ree_fs_new_rename(size_t num_params,
 static TEEC_Result ree_fs_new_opendir(size_t num_params,
 				      struct tee_ioctl_param *params)
 {
-	char abs_filename[PATH_MAX];
-	char *fname;
-	DIR *dir;
-	int handle;
-	struct dirent *dent;
+	char abs_filename[PATH_MAX] = { 0 };
+	char *fname = NULL;
+	DIR *dir = NULL;
+	int handle = 0;
+	struct dirent *dent = NULL;
 	bool empty = true;
 
 	if (num_params != 3 ||
@@ -542,7 +544,7 @@ static TEEC_Result ree_fs_new_opendir(size_t num_params,
 static TEEC_Result ree_fs_new_closedir(size_t num_params,
 				       struct tee_ioctl_param *params)
 {
-	DIR *dir;
+	DIR *dir = NULL;
 
 	if (num_params != 1 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
@@ -561,11 +563,11 @@ static TEEC_Result ree_fs_new_closedir(size_t num_params,
 static TEEC_Result ree_fs_new_readdir(size_t num_params,
 				      struct tee_ioctl_param *params)
 {
-	DIR *dir;
-	struct dirent *dirent;
-	char *buf;
-	size_t len;
-	size_t fname_len;
+	DIR *dir = NULL;
+	struct dirent *dirent = NULL;
+	char *buf = NULL;
+	size_t len = 0;
+	size_t fname_len = 0;
 
 	if (num_params != 2 ||
 	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=

--- a/tee-supplicant/src/teec_ta_load.c
+++ b/tee-supplicant/src/teec_ta_load.c
@@ -81,11 +81,11 @@ static int try_load_secure_module(const char* prefix,
 				  const TEEC_UUID *destination, void *ta,
 				  size_t *ta_size)
 {
-	char fname[PATH_MAX];
+	char fname[PATH_MAX] = { 0 };
 	FILE *file = NULL;
 	bool first_try = true;
-	size_t s;
-	int n;
+	size_t s = 0;
+	int n = 0;
 
 	if (!ta_size || !destination) {
 		printf("wrong inparameter to TEECI_LoadSecureModule\n");
@@ -169,7 +169,7 @@ int TEECI_LoadSecureModule(const char* dev_path,
 			   size_t *ta_size)
 {
 #ifdef TEEC_TEST_LOAD_PATH
-	int res;
+	int res = 0;
 
 	res = try_load_secure_module(TEEC_TEST_LOAD_PATH,
 				     dev_path, destination, ta, ta_size);


### PR DESCRIPTION
This change initializes all local variables to prevent build issues
(warnings and/or errors) in OP-TEE client package.

Use memset() to init structured and typed variables. This change
changes ordering in the local variable definition block at function
head. Structured variables are defined below, right above the memset()
call block for their initialization, when possible.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>