### PR TITLE
libteec: fix clang build errors

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -490,11 +490,12 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 	TEEC_Result res = 0;
 	uint32_t eorig = 0;
 	int rc = 0;
-	size_t p_sz = TEEC_CONFIG_PAYLOAD_REF_COUNT *
-		      sizeof(struct tee_ioctl_param);
+	const size_t arg_size = sizeof(struct tee_ioctl_open_session_arg) +
+				TEEC_CONFIG_PAYLOAD_REF_COUNT *
+					sizeof(struct tee_ioctl_param);
 	union {
 		struct tee_ioctl_open_session_arg arg;
-		uint8_t data[sizeof(struct tee_ioctl_open_session_arg) + p_sz];
+		uint8_t data[arg_size];
 	} buf;
 	struct tee_ioctl_buf_data buf_data;
 	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];
@@ -572,11 +573,12 @@ TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
 	TEEC_Result res = 0;
 	uint32_t eorig = 0;
 	int rc = 0;
-	size_t p_sz = TEEC_CONFIG_PAYLOAD_REF_COUNT *
-		      sizeof(struct tee_ioctl_param);
+	const size_t arg_size = sizeof(struct tee_ioctl_invoke_arg) +
+				TEEC_CONFIG_PAYLOAD_REF_COUNT *
+					sizeof(struct tee_ioctl_param);
 	union {
 		struct tee_ioctl_invoke_arg arg;
-		uint8_t data[sizeof(struct tee_ioctl_invoke_arg) + p_sz];
+		uint8_t data[arg_size];
 	} buf;
 	struct tee_ioctl_buf_data buf_data;
 	TEEC_SharedMemory shm[TEEC_CONFIG_PAYLOAD_REF_COUNT];


### PR DESCRIPTION
external/optee_client/libteec/src/tee_client_api.c:488:11: error: fields must have a constant size: 'variable length array in structure' extension will never be supported
                uint8_t data[sizeof(struct tee_ioctl_open_session_arg) + p_sz];
                        ^
external/optee_client/libteec/src/tee_client_api.c:566:11: error: fields must have a constant size: 'variable length array in structure' extension will never be supported
                uint8_t data[sizeof(struct tee_ioctl_invoke_arg) + p_sz];
                        ^

Fixes: 9dbc61b3 ("libteec: fix build warnings")
Fixes: https://github.com/OP-TEE/optee_client/issues/152

Signed-off-by: Victor Chong <victor.chong@linaro.org>