### PR TITLE
Initialize structured local variable where defined

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -487,7 +487,7 @@ TEEC_Result TEEC_OpenSession(TEEC_Context *ctx, TEEC_Session *session,
 {
 	struct tee_ioctl_open_session_arg *arg = NULL;
 	struct tee_ioctl_param *params = NULL;
-	TEEC_Result res = 0;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	uint32_t eorig = 0;
 	int rc = 0;
 	const size_t arg_size = sizeof(struct tee_ioctl_open_session_arg) +
@@ -570,7 +570,7 @@ TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
 {
 	struct tee_ioctl_invoke_arg *arg = NULL;
 	struct tee_ioctl_param *params = NULL;
-	TEEC_Result res = 0;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	uint32_t eorig = 0;
 	int rc = 0;
 	const size_t arg_size = sizeof(struct tee_ioctl_invoke_arg) +
@@ -718,7 +718,6 @@ TEEC_Result TEEC_RegisterSharedMemoryFileDescriptor(TEEC_Context *ctx,
 	if (!shm->flags || (shm->flags & ~(TEEC_MEM_INPUT | TEEC_MEM_OUTPUT)))
 		return TEEC_ERROR_BAD_PARAMETERS;
 
-	memset(&data, 0, sizeof(data));
 	data.fd = fd;
 	rfd = ioctl(ctx->fd, TEE_IOC_SHM_REGISTER_FD, &data);
 	if (rfd < 0)

--- a/tee-supplicant/src/rpmb.c
+++ b/tee-supplicant/src/rpmb.c
@@ -598,13 +598,13 @@ static void close_mmc_fd(int fd)
 static uint32_t read_ext_csd(int fd, uint8_t *ext_csd)
 {
 	int st = 0;
-	struct mmc_ioc_cmd cmd;
+	struct mmc_ioc_cmd cmd = {
+		.blksz = 512,
+		.blocks = 1,
+		.flags = MMC_RSP_R1 | MMC_CMD_ADTC,
+		.opcode = MMC_SEND_EXT_CSD,
+	};
 
-	memset(&cmd, 0, sizeof(cmd));
-	cmd.blksz = 512;
-	cmd.blocks = 1;
-	cmd.flags = MMC_RSP_R1 | MMC_CMD_ADTC;
-	cmd.opcode = MMC_SEND_EXT_CSD;
 	mmc_ioc_cmd_set_data(cmd, ext_csd);
 
 	st = IOCTL(fd, MMC_IOC_CMD, &cmd);
@@ -621,15 +621,14 @@ static uint32_t rpmb_data_req(int fd, struct rpmb_data_frame *req_frm,
 	int st = 0;
 	size_t i = 0;
 	uint16_t msg_type = ntohs(req_frm->msg_type);
-	struct mmc_ioc_cmd cmd;
-
-	memset(&cmd, 0, sizeof(cmd));
-	cmd.blksz = 512;
-	cmd.blocks = req_nfrm;
-	cmd.data_ptr = (uintptr_t)req_frm;
-	cmd.flags = MMC_RSP_R1 | MMC_CMD_ADTC;
-	cmd.opcode = MMC_WRITE_MULTIPLE_BLOCK;
-	cmd.write_flag = 1;
+	struct mmc_ioc_cmd cmd = {
+		.blksz = 512,
+		.blocks = req_nfrm,
+		.data_ptr = (uintptr_t)req_frm,
+		.flags = MMC_RSP_R1 | MMC_CMD_ADTC,
+		.opcode = MMC_WRITE_MULTIPLE_BLOCK,
+		.write_flag = 1,
+	};
 
 	for (i = 1; i < req_nfrm; i++) {
 		if (req_frm[i].msg_type != msg_type) {

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -584,7 +584,6 @@ static bool process_one_request(struct thread_arg *arg)
 	memset(&request, 0, sizeof(request));
 
 	DMSG("looping");
-	memset(&request, 0, sizeof(request));
 	request.recv.num_params = RPC_NUM_PARAMS;
 
 	/* Let it be known that we can deal with meta parameters */


### PR DESCRIPTION
Prefer using = { } rather than explicit memset() for default
initialization of structure local variables. The rational is that
memset() are implemented below variable definition block whereas
such default initialization is more explicit if done exactly where
the variable is define, non structured/enumerated type local variables.

When not possible, use = { 0 } or memset().