### PR TITLE
[RFC] tee-supplicant: Add ftrace buffer dump support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ LIBDIR ?= /usr/lib
 INCLUDEDIR ?= /usr/include
 
 CFG_TA_GPROF_SUPPORT ?= n
+CFG_TA_FTRACE_SUPPORT ?= n
 
 .PHONY: all build build-libteec install copy_export \
 	clean cscope clean-cscope \

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -5,7 +5,8 @@ project (tee-supplicant C)
 ################################################################################
 option (CFG_TA_TEST_PATH "Enable tee-supplicant to load from test/debug path" OFF)
 option (RPMB_EMU "Enable tee-supplicant to emulate RPMB" ON)
-option (CFG_TA_GPROF_SUPPORT "Enabled tee-supplicant profiling support" OFF)
+option (CFG_TA_GPROF_SUPPORT "Enable tee-supplicant support for TAs instrumented with gprof" OFF)
+option (CFG_TA_FTRACE_SUPPORT "Enable tee-supplicant support for TAs instrumented with ftrace" OFF)
 
 set (CFG_TEE_SUPP_LOG_LEVEL "1" CACHE STRING "tee-supplicant log level")
 # FIXME: Question is, is this really needed? Should just use defaults from # GNUInstallDirs?
@@ -31,8 +32,8 @@ if (CFG_GP_SOCKETS)
 	set (SRC ${SRC} src/tee_socket.c)
 endif()
 
-if (CFG_TA_GPROF_SUPPORT)
-	set (SRC ${SRC} src/gprof.c)
+if (CFG_TA_GPROF_SUPPORT OR CFG_TA_FTRACE_SUPPORT)
+	set (SRC ${SRC} src/prof.c)
 endif()
 
 ################################################################################
@@ -71,6 +72,11 @@ endif()
 if (CFG_TA_GPROF_SUPPORT)
 	target_compile_definitions (${PROJECT_NAME}
 		PRIVATE -DCFG_TA_GPROF_SUPPORT)
+endif()
+
+if (CFG_TA_FTRACE_SUPPORT)
+	target_compile_definitions (${PROJECT_NAME}
+		PRIVATE -DCFG_TA_FTRACE_SUPPORT)
 endif()
 
 ################################################################################

--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -28,8 +28,8 @@ endif
 ifeq ($(RPMB_EMU),1)
 TEES_SRCS	+= sha2.c hmac_sha2.c
 endif
-ifeq ($(CFG_TA_GPROF_SUPPORT),y)
-TEES_SRCS	+= gprof.c
+ifneq (,$(filter y,$(CFG_TA_GPROF_SUPPORT) $(CFG_TA_FTRACE_SUPPORT)))
+TEES_SRCS	+= prof.c
 endif
 
 TEES_SRC_DIR	:= src
@@ -59,6 +59,10 @@ TEES_LFLAGS    := $(LDFLAGS) -L$(OUT_DIR)/../libteec -lteec
 
 ifeq ($(CFG_TA_GPROF_SUPPORT),y)
 TEES_CFLAGS	+= -DCFG_TA_GPROF_SUPPORT
+endif
+
+ifeq ($(CFG_TA_FTRACE_SUPPORT),y)
+TEES_CFLAGS	+= -DCFG_TA_FTRACE_SUPPORT
 endif
 
 TEES_LFLAGS	+= -lpthread

--- a/tee-supplicant/src/optee_msg_supplicant.h
+++ b/tee-supplicant/src/optee_msg_supplicant.h
@@ -178,6 +178,11 @@
  */
 #define OPTEE_MSG_RPC_CMD_SOCKET	10
 
+/*
+ * Function tracing support management commands
+ */
+#define OPTEE_MSG_RPC_CMD_FTRACE	11
+
 
 /*
  * Define protocol for messages with .cmd == OPTEE_MSG_RPC_CMD_SOCKET

--- a/tee-supplicant/src/prof.h
+++ b/tee-supplicant/src/prof.h
@@ -25,27 +25,30 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GPROF_H
-#define GPROF_H
+#ifndef PROF_H
+#define PROF_H
 
 #include <tee_client_api.h>
 
 struct tee_ioctl_param;
 
-#if defined(CFG_TA_GPROF_SUPPORT)
+#if defined(CFG_TA_GPROF_SUPPORT) || defined(CFG_TA_FTRACE_SUPPORT)
 
-TEEC_Result gprof_process(size_t num_params, struct tee_ioctl_param *params);
+TEEC_Result prof_process(size_t num_params, struct tee_ioctl_param *params,
+			 const char *prefix);
 
 #else
 
-static inline TEEC_Result gprof_process(size_t num_params,
-					struct tee_ioctl_param *params)
+static inline TEEC_Result prof_process(size_t num_params,
+				       struct tee_ioctl_param *params,
+				       const char *prefix)
 {
 	(void)num_params;
 	(void)params;
+	(void)prefix;
 
 	return TEEC_ERROR_NOT_SUPPORTED;
 }
 
-#endif /* CFG_TA_GPROF_SUPPORT */
-#endif /* GPROF_H */
+#endif /* CFG_TA_GPROF_SUPPORT || CFG_TA_FTRACE_SUPPORT */
+#endif /* PROF_H */

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -31,8 +31,8 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <gprof.h>
 #include <inttypes.h>
+#include <prof.h>
 #include <pthread.h>
 #include <rpmb.h>
 #include <stdbool.h>
@@ -618,10 +618,13 @@ static bool process_one_request(struct thread_arg *arg)
 		ret = process_free(num_params, params);
 		break;
 	case OPTEE_MSG_RPC_CMD_GPROF:
-		ret = gprof_process(num_params, params);
+		ret = prof_process(num_params, params, "gmon-");
 		break;
 	case OPTEE_MSG_RPC_CMD_SOCKET:
 		ret = tee_socket_process(num_params, params);
+		break;
+	case OPTEE_MSG_RPC_CMD_FTRACE:
+		ret = prof_process(num_params, params, "ftrace-");
 		break;
 	default:
 		EMSG("Cmd [0x%" PRIx32 "] not supported", func);

--- a/tee-supplicant/tee_supplicant_android.mk
+++ b/tee-supplicant/tee_supplicant_android.mk
@@ -36,9 +36,16 @@ LOCAL_SRC_FILES += src/sha2.c src/hmac_sha2.c
 LOCAL_CFLAGS += -DRPMB_EMU=1
 endif
 
+ifneq (,$(filter y,$(CFG_TA_GPROF_SUPPORT) $(CFG_TA_FTRACE_SUPPORT)))
+LOCAL_SRC_FILES += src/prof.c
+endif
+
 ifeq ($(CFG_TA_GPROF_SUPPORT),y)
-LOCAL_SRC_FILES += src/gprof.c
 LOCAL_CFLAGS += -DCFG_TA_GPROF_SUPPORT
+endif
+
+ifeq ($(CFG_TA_FTRACE_SUPPORT),y)
+LOCAL_CFLAGS += -DCFG_TA_FTRACE_SUPPORT
 endif
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../public \


### PR DESCRIPTION
Make gprof dump framework common to utilize for ftrace buffer dump
support.

This is inline to optee_os support for ftrace feature for user TAs, PR: https://github.com/OP-TEE/optee_os/pull/2912.

Looking forward to your comments.

Regards,
Sumit