### PR TITLE
tee-supplicant: ioctl_emu_read_ctr(): MAC correct data

### DIFF
--- a/tee-supplicant/src/rpmb.c
+++ b/tee-supplicant/src/rpmb.c
@@ -440,6 +440,7 @@ static void ioctl_emu_read_ctr(struct rpmb_emu *mem,
 	frm->msg_type = htons(RPMB_MSG_TYPE_RESP_WRITE_COUNTER_VAL_READ);
 	frm->write_counter = htonl(mem->write_counter);
 	memcpy(frm->nonce, mem->nonce, 16);
+	frm->op_result = RPMB_RESULT_OK;
 	frm->op_result = compute_hmac(mem, frm, 1);
 }
 


### PR DESCRIPTION
Prior to this patch was ioctl_emu_read_ctr() calculating a MAC over
among other things the uninitialized "op_result". "op_result" often
happens to be 0 which is the same as RPMB_RESULT_OK which is returned by
compute_hmac() on success. However, this field is not initialized before
calculating the MAC so it could very well differ resulting in an invalid
MAC. This patch fixes this by initializing "op_result" to RPMB_RESULT_OK
before calculating the MAC.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>