### PR TITLE
simplify use of TEE fs related configs

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -6,10 +6,9 @@ LOCAL_PATH := $(call my-dir)
 # set CFG_TEE_CLIENT_LOAD_PATH before include config.mk
 CFG_TEE_CLIENT_LOAD_PATH ?= /vendor/lib
 
-# set CFG_TEE_DATA_PATH before include config.mk
-CFG_TEE_DATA_PATH ?= /data/vendor/tee
+# set CFG_TEE_FS_PARENT_PATH before include config.mk
 TEEC_TEST_LOAD_PATH ?= /data/vendor/tee
-CFG_TEE_FS_PARENT_PATH ?= /data/vendor
+CFG_TEE_FS_PARENT_PATH ?= /data/vendor/tee
 
 ################################################################################
 # Include optee-client common config and flags                                 #

--- a/config.mk
+++ b/config.mk
@@ -23,19 +23,12 @@ CFG_TEE_SUPP_LOG_LEVEL?=1
 #   This folder can be created with the required permission in an init
 #   script during boot, else it will be created by the tee-supplicant on
 #   first REE FS access.
-CFG_TEE_FS_PARENT_PATH ?= /data
-
-# CFG_TEE_DATA_PATH
-#   Specify the root path for the TEE data directory.
-#   This folder can be created with the required permission in an init
-#   script during boot, else it wil be created by the tee-supplicant on
-#   first REE FS access.
-CFG_TEE_DATA_PATH ?= $(CFG_TEE_FS_PARENT_PATH)/vendor/tee
+CFG_TEE_FS_PARENT_PATH ?= /data/tee
 
 # CFG_TEE_LOGS_PATH
 #   Specify the root path for the TEE logs directory.
-#   Normally it will be the logs directory under $(CFG_TEE_DATA_PATH)
-CFG_TEE_LOGS_PATH ?= $(CFG_TEE_DATA_PATH)/logs
+#   Normally it will be the logs directory under $(CFG_TEE_FS_PARENT_PATH)
+CFG_TEE_LOGS_PATH ?= $(CFG_TEE_FS_PARENT_PATH)/logs
 
 # CFG_TEE_CLIENT_LOG_FILE
 #   The location of the client log file when logging to file is enabled.

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -10,7 +10,7 @@ option (CFG_TA_GPROF_SUPPORT "Enabled tee-supplicant profiling support" OFF)
 set (CFG_TEE_SUPP_LOG_LEVEL "1" CACHE STRING "tee-supplicant log level")
 # FIXME: Question is, is this really needed? Should just use defaults from # GNUInstallDirs?
 set (CFG_TEE_CLIENT_LOAD_PATH "/lib" CACHE STRING "Location of libteec.so")
-set (CFG_TEE_FS_PARENT_PATH "/data" CACHE STRING "Location of TEE filesystem (secure storage)")
+set (CFG_TEE_FS_PARENT_PATH "/data/tee" CACHE STRING "Location of TEE filesystem (secure storage)")
 # FIXME: Why do we have if defined(CFG_GP_SOCKETS) && CFG_GP_SOCKETS == 1 in the c-file?
 set (CFG_GP_SOCKETS "1" CACHE STRING "Enable GlobalPlatform Socket API support")
 

--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -121,7 +121,7 @@ static int tee_supp_fs_init(void)
 	size_t n = 0;
 	mode_t mode = 0700;
 
-	n = snprintf(tee_fs_root, sizeof(tee_fs_root), "%s/tee/", TEE_FS_PARENT_PATH);
+	n = snprintf(tee_fs_root, sizeof(tee_fs_root), "%s/", TEE_FS_PARENT_PATH);
 	if (n >= sizeof(tee_fs_root))
 		return -1;
 
@@ -612,7 +612,7 @@ TEEC_Result tee_supp_fs_process(size_t num_params,
 
 	if (strlen(tee_fs_root) == 0) {
 		if (tee_supp_fs_init() != 0) {
-			EMSG("error tee_supp_fs_init: failed to create %s/tee/",
+			EMSG("error tee_supp_fs_init: failed to create %s/",
 				TEE_FS_PARENT_PATH);
 			memset(tee_fs_root, 0, sizeof(tee_fs_root));
 			return TEEC_ERROR_STORAGE_NOT_AVAILABLE;


### PR DESCRIPTION
CFG_TEE_DATA_PATH confuses users because it's only used as a prefix for
CFG_TEE_LOGS_PATH and not the actual root path for the TEE data dir as
described. The actual root path is $(TEE_FS_PARENT_PATH)/tee as can be
seen under tee_supp_fs_init() in tee-supplicant/src/tee_supp_fs.c, so
just get rid of CFG_TEE_DATA_PATH.

Next, we move "/tee" from tee_supp_fs_init() to CFG_TEE_FS_PARENT_PATH,
because otherwise, we have the beginning part of the path in a makefile
(config.mk) and the ending in code (tee_supp_fs_init()), which seems
messy to manage and error prone. E.g. CFG_TEE_LOGS_PATH (or any of its
subsequently derived configs) depends on the actual full path of the TEE
fs, so we can just set
CFG_TEE_LOGS_PATH ?= $(CFG_TEE_FS_PARENT_PATH)/logs
rather than
CFG_TEE_LOGS_PATH ?= $(CFG_TEE_FS_PARENT_PATH)/tee/logs
where the "tee" here has to match the "tee" in code.

Signed-off-by: Victor Chong <victor.chong@linaro.org>