### PR TITLE
config.mk: get rid of CFG_TEE_LOGS_PATH

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -25,14 +25,9 @@ CFG_TEE_SUPP_LOG_LEVEL?=1
 #   first REE FS access.
 CFG_TEE_FS_PARENT_PATH ?= /data/tee
 
-# CFG_TEE_LOGS_PATH
-#   Specify the root path for the TEE logs directory.
-#   Normally it will be the logs directory under $(CFG_TEE_FS_PARENT_PATH)
-CFG_TEE_LOGS_PATH ?= $(CFG_TEE_FS_PARENT_PATH)/logs
-
 # CFG_TEE_CLIENT_LOG_FILE
 #   The location of the client log file when logging to file is enabled.
-CFG_TEE_CLIENT_LOG_FILE ?= $(CFG_TEE_LOGS_PATH)/teec.log
+CFG_TEE_CLIENT_LOG_FILE ?= $(CFG_TEE_FS_PARENT_PATH)/teec.log
 
 # CFG_TEE_CLIENT_LOAD_PATH
 #   The location of the client library file.

--- a/libteec/CMakeLists.txt
+++ b/libteec/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 option (CFG_TEE_BENCHMARK "Build with benchmark support" OFF)
 
 set (CFG_TEE_CLIENT_LOG_LEVEL "1" CACHE STRING "libteec log level")
-set (CFG_TEE_CLIENT_LOG_FILE "/data/tee/logs/teec.log" CACHE STRING "Location of libteec log")
+set (CFG_TEE_CLIENT_LOG_FILE "/data/tee/teec.log" CACHE STRING "Location of libteec log")
 
 ################################################################################
 # Source files


### PR DESCRIPTION
CFG_TEE_CLIENT_LOG_FILE was originally /data/teec.log. Commit 9a63135b
("Android.mk & config.mk: move teec.log/teesupp.log under /data/tee")
introduced CFG_TEE_LOGS_PATH which placed teec.log under
/data/tee/logs/, but in nowhere (here or build.git) do we create the
'logs' dir, so fopen /data/tee/logs/teec.log fails and teec.log is
never created. To make things simple, remove CFG_TEE_LOGS_PATH and
just place teec.log under /data/tee.

Signed-off-by: Victor Chong <victor.chong@linaro.org>