### PR TITLE
[RFC] tee-supplicant: default enable ftrace a gprof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,6 @@ SBINDIR ?= /usr/sbin
 LIBDIR ?= /usr/lib
 INCLUDEDIR ?= /usr/include
 
-CFG_TA_GPROF_SUPPORT ?= n
-CFG_TA_FTRACE_SUPPORT ?= n
-
 .PHONY: all build build-libteec install copy_export \
 	clean cscope clean-cscope \
 	checkpatch-pre-req checkpatch-modified-patch checkpatch-modified-file \

--- a/config.mk
+++ b/config.mk
@@ -43,6 +43,16 @@ CFG_TA_TEST_PATH ?= n
 #   Enable Global Platform Sockets support
 CFG_GP_SOCKETS ?= y
 
+# CFG_TA_GPROF_SUPPORT
+#   Enable dumping gprof data, not used unless secure world decides
+#   to dump something
+CFG_TA_GPROF_SUPPORT ?= y
+
+# CFG_TA_FTRACE_SUPPORT
+#   Enable dumping ftrace data, not used unless secure world decides
+#   to dump something
+CFG_TA_FTRACE_SUPPORT ?= y
+
 # Default output directory.
 # May be absolute, or relative to the optee_client source directory.
 O               ?= out

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -5,8 +5,8 @@ project (tee-supplicant C)
 ################################################################################
 option (CFG_TA_TEST_PATH "Enable tee-supplicant to load from test/debug path" OFF)
 option (RPMB_EMU "Enable tee-supplicant to emulate RPMB" ON)
-option (CFG_TA_GPROF_SUPPORT "Enable tee-supplicant support for TAs instrumented with gprof" OFF)
-option (CFG_TA_FTRACE_SUPPORT "Enable tee-supplicant support for TAs instrumented with ftrace" OFF)
+option (CFG_TA_GPROF_SUPPORT "Enable tee-supplicant support for TAs instrumented with gprof" ON)
+option (CFG_TA_FTRACE_SUPPORT "Enable tee-supplicant support for TAs instrumented with ftrace" ON)
 
 set (CFG_TEE_SUPP_LOG_LEVEL "1" CACHE STRING "tee-supplicant log level")
 # FIXME: Question is, is this really needed? Should just use defaults from # GNUInstallDirs?


### PR DESCRIPTION
By default enables ftrace and gprof dumping. Not used unless secure
world decides to dump something.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>