### PR TITLE
Travis: install package libc6-dev-armhf-cross

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
 # Install the cross-compiler
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y gcc-arm-linux-gnueabihf
+  - sudo apt-get install -y gcc-arm-linux-gnueabihf libc6-dev-armhf-cross
   - arm-linux-gnueabihf-gcc --version
   # Travis does 'export CC=gcc'. Unset CC so that ./flags.mk properly
   # defines the cross-compiler to the default value: $(CROSS_COMPILE)gcc.


### PR DESCRIPTION
Travis CI have switched their default distribution from Ubuntu 14.04.5
to 16.04.6. Now we have the following build error:

   CC      src/tee_client_api.c
 In file included from /usr/include/errno.h:28:0,
                  from src/tee_client_api.c:28:
 /usr/include/features.h:367:25: fatal error: sys/cdefs.h: No such file or directory

The missing file is in the libc6-dev-armhf-cross package.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>