### PR TITLE
libteec: implement OCALLs

### DIFF
--- a/libteec/CMakeLists.txt
+++ b/libteec/CMakeLists.txt
@@ -1,6 +1,10 @@
 project(libteec C)
 
-set(PROJECT_VERSION "1.0.0")
+set(MAJOR_VERSION 2)
+set(MINOR_VERSION 0)
+set(PATCH_VERSION 0)
+
+set(PROJECT_VERSION "${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}")
 
 ################################################################################
 # Packages
@@ -37,7 +41,7 @@ add_library (teec ${SRC})
 
 set_target_properties (teec PROPERTIES
 	VERSION ${PROJECT_VERSION}
-	SOVERSION 1
+	SOVERSION ${MAJOR_VERSION}
 )
 
 ################################################################################

--- a/libteec/Makefile
+++ b/libteec/Makefile
@@ -9,7 +9,7 @@ all: libteec
 ################################################################################
 # Teec configuration
 ################################################################################
-MAJOR_VERSION	:= 1
+MAJOR_VERSION	:= 2
 MINOR_VERSION	:= 0
 PATCH_VERSION	:= 0
 LIB_NAME	:= libteec.so

--- a/libteec/include/linux/tee.h
+++ b/libteec/include/linux/tee.h
@@ -53,6 +53,7 @@
 #define TEE_GEN_CAP_PRIVILEGED	(1 << 1)/* Privileged device (for supplicant) */
 #define TEE_GEN_CAP_REG_MEM	(1 << 2)/* Supports registering shared memory */
 #define TEE_GEN_CAP_MEMREF_NULL	(1 << 3) /* Support NULL MemRef */
+#define TEE_GEN_CAP_OCALL	(1 << 4) /* Supports calls from TA to CA */
 
 #define TEE_MEMREF_NULL		((__u64)-1) /* NULL MemRef Buffer */
 

--- a/libteec/include/linux/tee.h
+++ b/libteec/include/linux/tee.h
@@ -43,6 +43,7 @@
 #define TEE_IOC_BASE	0
 
 /* Flags relating to shared memory */
+#define TEE_IOCTL_SHM_NONE	0x0	/* no flags */
 #define TEE_IOCTL_SHM_MAPPED	0x1	/* memory mapped in normal world */
 #define TEE_IOCTL_SHM_DMA_BUF	0x2	/* dma-buf handle on shared memory */
 

--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -175,6 +175,7 @@ TEEC_Result TEEC_InitializeContext(const char *name, TEEC_Context *ctx)
 			ctx->fd = fd;
 			ctx->reg_mem = gen_caps & TEE_GEN_CAP_REG_MEM;
 			ctx->memref_null = gen_caps & TEE_GEN_CAP_MEMREF_NULL;
+			ctx->ocall = gen_caps & TEE_GEN_CAP_OCALL;
 			return TEEC_SUCCESS;
 		}
 	}

--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -198,11 +198,14 @@ extern "C" {
  * TEEC_ORIGIN_TEE          The error originated within the common TEE code.
  * TEEC_ORIGIN_TRUSTED_APP  The error originated within the Trusted Application
  *                          code.
+ * TEEC_ORIGIN_CLIENT_APP   The error originated within the Client Application
+ *                          code during an OCALL.
  */
 #define TEEC_ORIGIN_API          0x00000001
 #define TEEC_ORIGIN_COMMS        0x00000002
 #define TEEC_ORIGIN_TEE          0x00000003
 #define TEEC_ORIGIN_TRUSTED_APP  0x00000004
+#define TEEC_ORIGIN_CLIENT_APP   0xF0000001
 
 /**
  * Session login methods, for use in TEEC_OpenSession() as parameter
@@ -245,6 +248,14 @@ extern "C" {
  * @param i The i-th parameter to get the type for.
  */
 #define TEEC_PARAM_TYPE_GET(p, i) (((p) >> (i * 4)) & 0xF)
+
+/**
+ * Set the i_th param type in the paramType.
+ *
+ * @param p The paramType.
+ * @param i The i-th parameter to set the type for.
+ */
+#define TEEC_PARAM_TYPE_SET(p, i) (((uint32_t)(p) & 0xF) << ((i) * 4))
 
 typedef uint32_t TEEC_Result;
 

--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -434,6 +434,39 @@ typedef struct {
 } TEEC_Context;
 
 /**
+ * enum TEEC_SessionSettingType - List of available settings when initializing a
+ * session.
+ */
+typedef enum {
+	TEEC_SESSION_SETTING_DATA = 1
+} TEEC_SessionSettingType;
+
+/**
+ * struct TEEC_SessionSettingData - Setting to attach an arbitrary pointer to a
+ * session; useful when handling OCALLs if per-session data is required by the
+ * OCALL handler.
+ *
+ * @param data  Arbitrary pointer to pass to the OCALL handler function via
+ *              @sessionData.
+ */
+typedef struct {
+	void *data;
+} TEEC_SessionSettingData;
+
+/**
+ * struct TEEC_SessionSetting - A setting to be used when opening a session.
+ *
+ * @param type  The type of setting this is (i.e., how to interpret the union).
+ * @param u     Union of all possible settings.
+ */
+typedef struct {
+	TEEC_SessionSettingType type;
+	union {
+		const TEEC_SessionSettingData *data;
+	} u;
+} TEEC_SessionSetting;
+
+/**
  * struct TEEC_Session - Represents a connection between a client application
  * and a trusted application.
  */
@@ -441,6 +474,7 @@ typedef struct {
 	/* Implementation defined */
 	TEEC_Context *ctx;
 	uint32_t session_id;
+	TEEC_SessionSettingData data_setting;
 } TEEC_Session;
 
 /**

--- a/public/tee_client_api_extensions.h
+++ b/public/tee_client_api_extensions.h
@@ -73,6 +73,42 @@ TEEC_Result TEEC_InitializeContext2(const char *name, TEEC_Context *context,
 				    const TEEC_ContextSetting *settings,
 				    uint32_t numSettings);
 
+/**
+ * TEEC_OpenSession2() - Behaves the same way as TEEC_OpenSession allowing the
+ * caller to attach the specified settings to the resulting session.
+ *
+ * @param context           The initialized TEE context structure in which scope
+ *                          to open the session.
+ * @param session           The session to initialize.
+ * @param destination       A structure identifying the trusted application with
+ *                          which to open a session.
+ * @param connectionMethod  The connection method to use.
+ * @param connectionData    Any data necessary to connect with the chosen
+ *                          connection method. Not supported, should be set to
+ *                          NULL.
+ * @param operation         An operation structure to use in the session. May be
+ *                          set to NULL to signify no operation structure
+ *                          needed.
+ * @param returnOrigin      A parameter which will hold the error origin if this
+ *                          function returns any value other than TEEC_SUCCESS.
+ * @param settings          A list of settings to use to configure the new
+ *                          session, or NULL.
+ * @param numSettings       The number of settings, if any.
+ *
+ * @return TEEC_SUCCESS               Successfully opened a new session.
+ * @return TEEC_ERROR_BAD_PARAMETERS  One or more parameters are wrong.
+ * @return TEEC_Result                Something else failed.
+ */
+TEEC_Result TEEC_OpenSession2(TEEC_Context *context,
+			      TEEC_Session *session,
+			      const TEEC_UUID *destination,
+			      uint32_t connectionMethod,
+			      const void *connectionData,
+			      TEEC_Operation *operation,
+			      uint32_t *returnOrigin,
+			      const TEEC_SessionSetting *settings,
+			      uint32_t numSettings);
+
 #ifdef __cplusplus
 }
 #endif

--- a/public/tee_client_api_extensions.h
+++ b/public/tee_client_api_extensions.h
@@ -50,6 +50,29 @@ TEEC_Result TEEC_RegisterSharedMemoryFileDescriptor(TEEC_Context *context,
 						    TEEC_SharedMemory *sharedMem,
 						    int fd);
 
+/**
+ * TEEC_InitializeContext2() - Behaves the same way as TEEC_InitializeContext
+ * allowing the caller to attach the specified settings to the resulting
+ * context.
+ *
+ * @param name         A zero-terminated string identifying the TEE to connect
+ *                     to. If name is set to NULL, the default TEE is connected
+ *                     to. NULL is the only supported value in this version of
+ *                     the API implementation.
+ * @param context      The context structure which is to be initialized.
+ * @param settings     A list of settings to use to configure the new
+ *                     context, or NULL.
+ * @param numSettings  The number of settings, if any.
+ *
+ * @return TEEC_SUCCESS               The initialization was successful.
+ * @return TEEC_ERROR_BAD_PARAMETERS  One or more parameters are wrong.
+ * @return TEEC_ERROR_NOT_SUPPORTED   One or more settings are not supported.
+ * @return TEEC_Result                Something else failed.
+ */
+TEEC_Result TEEC_InitializeContext2(const char *name, TEEC_Context *context,
+				    const TEEC_ContextSetting *settings,
+				    uint32_t numSettings);
+
 #ifdef __cplusplus
 }
 #endif

--- a/typedefs.checkpatch
+++ b/typedefs.checkpatch
@@ -1,15 +1,15 @@
 # Note: please keep the entries in this file sorted in reverse alphabetical
 # order (sort -r)
-TEEC_Result
-TEEC_Context
-TEEC_UUID
-TEEC_SharedMemory
-TEEC_TempMemoryReference
-TEEC_RegisteredMemoryReference
 TEEC_Value
-TEEC_Parameter
+TEEC_UUID
+TEEC_TempMemoryReference
+TEEC_SharedMemory
 TEEC_Session
+TEEC_Result
+TEEC_RegisteredMemoryReference
+TEEC_Parameter
 TEEC_Operation
+TEEC_Context
 CK_VOID_PTR_PTR
 CK_VOID_PTR
 CK_VERSION_PTR
@@ -61,9 +61,9 @@ CK_FLAGS
 CK_DESTROYMUTEX
 CK_DATE_PTR
 CK_DATE
-CK_CREATEMUTEX
 CK_C_INITIALIZE_ARGS_PTR
 CK_C_INITIALIZE_ARGS
+CK_CREATEMUTEX
 CK_CHAR_PTR
 CK_CHAR
 CK_CCM_PARAMS_PTR

--- a/typedefs.checkpatch
+++ b/typedefs.checkpatch
@@ -4,6 +4,9 @@ TEEC_Value
 TEEC_UUID
 TEEC_TempMemoryReference
 TEEC_SharedMemory
+TEEC_SessionSettingType
+TEEC_SessionSettingData
+TEEC_SessionSetting
 TEEC_Session
 TEEC_Result
 TEEC_RegisteredMemoryReference

--- a/typedefs.checkpatch
+++ b/typedefs.checkpatch
@@ -17,6 +17,7 @@ TEEC_ContextSettingType
 TEEC_ContextSettingOCall
 TEEC_ContextSetting
 TEEC_Context
+SLIST_ENTRY\(.*\)
 CK_VOID_PTR_PTR
 CK_VOID_PTR
 CK_VERSION_PTR

--- a/typedefs.checkpatch
+++ b/typedefs.checkpatch
@@ -9,6 +9,10 @@ TEEC_Result
 TEEC_RegisteredMemoryReference
 TEEC_Parameter
 TEEC_Operation
+TEEC_OCallHandler
+TEEC_ContextSettingType
+TEEC_ContextSettingOCall
+TEEC_ContextSetting
 TEEC_Context
 CK_VOID_PTR_PTR
 CK_VOID_PTR


### PR DESCRIPTION
# Overview
This PR implements OCALLs in the TEE Client API.

**Related PRs:** [OP-TEE](https://github.com/OP-TEE/optee_os/pull/3673), [Linux](https://github.com/linaro-swg/linux/pull/72), [OP-TEE Examples](https://github.com/linaro-swg/optee_examples/pull/64).

## Session Open
A new function is added, `TEEC_OpenSessionEx`, whose signature is identical to `TEEC_OpenSession`, but takes two additional parameters. The first is an array of typed settings, while the second provides the number of settings in the array.

One such setting is the OCALL setting, which allows the developer to specify a callback for whenever an OCALL arrives, as well as an arbitrary context pointer.

The rationale behind using session settings is that it is conceivable that in the future, additional features are added that require configuration. Instead of creating new, independent functions to deal with those new features, a new setting type can be added and the existing API set remains the same. The Open Enclave SDK implements a similar pattern for its [`oe_create_enclave`](https://github.com/openenclave/openenclave/blob/master/include/openenclave/host.h#L149) function.

When the OCALL setting is specified in `TEEC_OpenSessionEx`, it checks that the underlying context reports that OP-TEE supports OCALLs. If so, it opens a session in the usual way via `TEEC_OpenSession`, then stores the OCALL configuration in the session object.

Sample usage:

```
TEEC_SessionSettingOcall ocall_setting = { my_ocall_handler, &my_context };
TEEC_SessionSetting settings[] = {
        { .type = TEEC_SESSION_SETTING_OCALL, .u.ocall = &ocall_setting }
};

res = TEEC_OpenSessionEx(&ctx, &sess, &uuid, TEEC_LOGIN_PUBLIC, NULL,
                         NULL, &err_origin, settings, 1);
```

## OCALL Handling
When OCALL support is configured, calls to `TEEC_InvokeFunction` are rerouted via the ECALL IOCTL instead of the INVOKE IOCTL. Around the IOCTL invocation, a loop exists to catch early returns, indicating that an OCALL request arrived. When that happens, the Client API takes care of dealing with shared memory allocation and free requests, as well as of parameter processing before and after dispatching an OCALL to the OCALL handler.

Signed-off-by: <hegatta@microsoft.com>