### PR TITLE
Remove obsolete toolchain variables reference in config.mk

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -66,9 +66,3 @@ OO := $(if $(filter /%,$(O)),$(O),$(CURDIR)/../$(O))
 
 # Check that settings are coherent.
 
-ifdef ARM_TOOLCHAIN_DIR
-ifeq ($(wildcard ${ARM_TOOLCHAIN_DIR}/bin/${ARM_GCC_PREFIX}-gcc),)
-  $(error "ARM_TOOLCHAIN_DIR wrongly setup. Is ${ARM_TOOLCHAIN_DIR}")
-endif
-endif
-


### PR DESCRIPTION
ARM_TOOLCHAIN_DIR and ARM_GCC_PREFIX aren't used for a long time and only mentioned in config.mk now.
This could be confusing, thus it's better to remove them.
