### PR TITLE
tee-supplicant: Rename ftrace config macro

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -48,10 +48,10 @@ CFG_GP_SOCKETS ?= y
 #   to dump something
 CFG_TA_GPROF_SUPPORT ?= y
 
-# CFG_TA_FTRACE_SUPPORT
+# CFG_FTRACE_SUPPORT
 #   Enable dumping ftrace data, not used unless secure world decides
 #   to dump something
-CFG_TA_FTRACE_SUPPORT ?= y
+CFG_FTRACE_SUPPORT ?= y
 
 # Default output directory.
 # May be absolute, or relative to the optee_client source directory.

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -6,7 +6,7 @@ project (tee-supplicant C)
 option (CFG_TA_TEST_PATH "Enable tee-supplicant to load from test/debug path" OFF)
 option (RPMB_EMU "Enable tee-supplicant to emulate RPMB" ON)
 option (CFG_TA_GPROF_SUPPORT "Enable tee-supplicant support for TAs instrumented with gprof" ON)
-option (CFG_TA_FTRACE_SUPPORT "Enable tee-supplicant support for TAs instrumented with ftrace" ON)
+option (CFG_FTRACE_SUPPORT "Enable tee-supplicant support for TAs instrumented with ftrace" ON)
 
 set (CFG_TEE_SUPP_LOG_LEVEL "1" CACHE STRING "tee-supplicant log level")
 # FIXME: Question is, is this really needed? Should just use defaults from # GNUInstallDirs?
@@ -32,7 +32,7 @@ if (CFG_GP_SOCKETS)
 	set (SRC ${SRC} src/tee_socket.c)
 endif()
 
-if (CFG_TA_GPROF_SUPPORT OR CFG_TA_FTRACE_SUPPORT)
+if (CFG_TA_GPROF_SUPPORT OR CFG_FTRACE_SUPPORT)
 	set (SRC ${SRC} src/prof.c)
 endif()
 
@@ -74,9 +74,9 @@ if (CFG_TA_GPROF_SUPPORT)
 		PRIVATE -DCFG_TA_GPROF_SUPPORT)
 endif()
 
-if (CFG_TA_FTRACE_SUPPORT)
+if (CFG_FTRACE_SUPPORT)
 	target_compile_definitions (${PROJECT_NAME}
-		PRIVATE -DCFG_TA_FTRACE_SUPPORT)
+		PRIVATE -DCFG_FTRACE_SUPPORT)
 endif()
 
 ################################################################################

--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -28,7 +28,7 @@ endif
 ifeq ($(RPMB_EMU),1)
 TEES_SRCS	+= sha2.c hmac_sha2.c
 endif
-ifneq (,$(filter y,$(CFG_TA_GPROF_SUPPORT) $(CFG_TA_FTRACE_SUPPORT)))
+ifneq (,$(filter y,$(CFG_TA_GPROF_SUPPORT) $(CFG_FTRACE_SUPPORT)))
 TEES_SRCS	+= prof.c
 endif
 
@@ -61,8 +61,8 @@ ifeq ($(CFG_TA_GPROF_SUPPORT),y)
 TEES_CFLAGS	+= -DCFG_TA_GPROF_SUPPORT
 endif
 
-ifeq ($(CFG_TA_FTRACE_SUPPORT),y)
-TEES_CFLAGS	+= -DCFG_TA_FTRACE_SUPPORT
+ifeq ($(CFG_FTRACE_SUPPORT),y)
+TEES_CFLAGS	+= -DCFG_FTRACE_SUPPORT
 endif
 
 TEES_LFLAGS	+= -lpthread

--- a/tee-supplicant/src/prof.h
+++ b/tee-supplicant/src/prof.h
@@ -32,7 +32,7 @@
 
 struct tee_ioctl_param;
 
-#if defined(CFG_TA_GPROF_SUPPORT) || defined(CFG_TA_FTRACE_SUPPORT)
+#if defined(CFG_TA_GPROF_SUPPORT) || defined(CFG_FTRACE_SUPPORT)
 
 TEEC_Result prof_process(size_t num_params, struct tee_ioctl_param *params,
 			 const char *prefix);
@@ -50,5 +50,5 @@ static inline TEEC_Result prof_process(size_t num_params,
 	return TEEC_ERROR_NOT_SUPPORTED;
 }
 
-#endif /* CFG_TA_GPROF_SUPPORT || CFG_TA_FTRACE_SUPPORT */
+#endif /* CFG_TA_GPROF_SUPPORT || CFG_FTRACE_SUPPORT */
 #endif /* PROF_H */

--- a/tee-supplicant/tee_supplicant_android.mk
+++ b/tee-supplicant/tee_supplicant_android.mk
@@ -36,7 +36,7 @@ LOCAL_SRC_FILES += src/sha2.c src/hmac_sha2.c
 LOCAL_CFLAGS += -DRPMB_EMU=1
 endif
 
-ifneq (,$(filter y,$(CFG_TA_GPROF_SUPPORT) $(CFG_TA_FTRACE_SUPPORT)))
+ifneq (,$(filter y,$(CFG_TA_GPROF_SUPPORT) $(CFG_FTRACE_SUPPORT)))
 LOCAL_SRC_FILES += src/prof.c
 endif
 
@@ -44,8 +44,8 @@ ifeq ($(CFG_TA_GPROF_SUPPORT),y)
 LOCAL_CFLAGS += -DCFG_TA_GPROF_SUPPORT
 endif
 
-ifeq ($(CFG_TA_FTRACE_SUPPORT),y)
-LOCAL_CFLAGS += -DCFG_TA_FTRACE_SUPPORT
+ifeq ($(CFG_FTRACE_SUPPORT),y)
+LOCAL_CFLAGS += -DCFG_FTRACE_SUPPORT
 endif
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../public \


### PR DESCRIPTION
Rename ftrace config macro from CFG_TA_FTRACE_SUPPORT to
CFG_FTRACE_SUPPORT as now with syscall function graph feature,
scope of ftrace has been enlarged to profile OP-TEE core as well.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>