### PR TITLE
ftrace, gprof: fix format of UUID string in file name

### DIFF
--- a/tee-supplicant/src/prof.c
+++ b/tee-supplicant/src/prof.c
@@ -101,7 +101,7 @@ TEEC_Result prof_process(size_t num_params, struct tee_ioctl_param *params,
 		}
 		n = snprintf(path, sizeof(path),
 			"/tmp/%s"
-			"%08x-%04x-%04x-%02x%02x%02x%02x%02x%02x%02x%02x"
+			"%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x"
 			"%s.out",
 			prefix,
 			u->timeLow, u->timeMid, u->timeHiAndVersion,


### PR DESCRIPTION
Function prof_process() creates a file in /tmp which is named after
the UUID passed to the function. The format of the UUID is not the
usual one; a dash is missing. Add it.

Signed-off-by: Jerome Forissier <jerome@forissier.org>