### PR TITLE
libckteec: invocation api function to register shared memory

### DIFF
--- a/libckteec/src/invoke_ta.c
+++ b/libckteec/src/invoke_ta.c
@@ -68,6 +68,40 @@ TEEC_SharedMemory *ckteec_alloc_shm(size_t size, enum ckteec_shm_dir dir)
 	return shm;
 }
 
+TEEC_SharedMemory *ckteec_register_shm(void *buffer, size_t size,
+				       enum ckteec_shm_dir dir)
+{
+	TEEC_SharedMemory *shm;
+
+	switch (dir) {
+	case CKTEEC_SHM_IN:
+	case CKTEEC_SHM_OUT:
+	case CKTEEC_SHM_INOUT:
+		break;
+	default:
+		return NULL;
+	}
+
+	shm = calloc(1, sizeof(TEEC_SharedMemory));
+	if (!shm)
+		return NULL;
+
+	shm->buffer = buffer;
+	shm->size = size;
+
+	if (dir == CKTEEC_SHM_IN || dir == CKTEEC_SHM_INOUT)
+		shm->flags |= TEEC_MEM_INPUT;
+	if (dir == CKTEEC_SHM_OUT || dir == CKTEEC_SHM_INOUT)
+		shm->flags |= TEEC_MEM_OUTPUT;
+
+	if (TEEC_RegisterSharedMemory(&ta_ctx.context, shm)) {
+		free(shm);
+		return NULL;
+	}
+
+	return shm;
+}
+
 void ckteec_free_shm(TEEC_SharedMemory *shm)
 {
 	TEEC_ReleaseSharedMemory(shm);

--- a/libckteec/src/invoke_ta.h
+++ b/libckteec/src/invoke_ta.h
@@ -26,6 +26,18 @@ enum ckteec_shm_dir {
 TEEC_SharedMemory *ckteec_alloc_shm(size_t size, enum ckteec_shm_dir dir);
 
 /**
+ * ckteec_register_shm - Register memory as shared in the TEE SHM
+ *
+ * @buffer - Base address of buffer to register
+ * @size - Allocated size in byte
+ * @dir - Data direction used for the shared memory
+ *
+ * Return a shm reference or NULL on failure.
+ */
+TEEC_SharedMemory *ckteec_register_shm(void *buffer, size_t size,
+				       enum ckteec_shm_dir dir);
+
+/**
  * ckteec_free_shm - Release allocated or registered emory in the TEE SHM
  *
  * @shm - memory reference


### PR DESCRIPTION
Add new API function ckteec_register_shm() to register in OP-TEE OS
a piece of Linux userland memory which a PKCS11 TA service will access
to, as an input data or output data buffer in a cryptography ciphering
sequence.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>