### PR TITLE
libckteec: assert api init/release functions return value compliance

### DIFF
--- a/libckteec/src/ck_helpers.c
+++ b/libckteec/src/ck_helpers.c
@@ -3,6 +3,11 @@
  * Copyright (c) 2020, Linaro Limited
  */
 
+#include <assert.h>
+#include <pkcs11.h>
+#include <stdio.h>
+#include <tee_client_api.h>
+
 #include "ck_helpers.h"
 
 CK_RV teec2ck_rv(TEEC_Result res)
@@ -20,3 +25,20 @@ CK_RV teec2ck_rv(TEEC_Result res)
 		return CKR_FUNCTION_FAILED;
 	}
 }
+
+#ifdef DEBUG
+void ckteec_assert_expected_rv(const char *function, CK_RV rv,
+			       const CK_RV *expected_rv, size_t expected_count)
+{
+	size_t n = 0;
+
+	for (n = 0; n < expected_count; n++)
+		if (rv == expected_rv[n])
+			return;
+
+	fprintf(stderr, "libckteec: unexpected return value 0x%lx for %s\n",
+		rv, function);
+
+	assert(0);
+}
+#endif

--- a/libckteec/src/ck_helpers.h
+++ b/libckteec/src/ck_helpers.h
@@ -9,6 +9,23 @@
 #include <pkcs11.h>
 #include <tee_client_api.h>
 
+#include "local_utils.h"
+
+#ifdef DEBUG
+#define ASSERT_CK_RV(_rv, ...)						\
+	do {								\
+		const CK_RV ref[] = { __VA_ARGS__ };			\
+		size_t count = ARRAY_SIZE(ref);				\
+									\
+		ckteec_assert_expected_rv(__func__, (_rv), ref, count);	\
+	} while (0)
+
+void ckteec_assert_expected_rv(const char *function, CK_RV rv,
+			       const CK_RV *expected_rv, size_t expected_count);
+#else
+#define ASSERT_CK_RV(_rv, ...)		(void)0
+#endif /*DEBUG*/
+
 /*
  * Convert IDs between PKCS11 TA and Cryptoki.
  */

--- a/libckteec/src/pkcs11_api.c
+++ b/libckteec/src/pkcs11_api.c
@@ -8,6 +8,7 @@
 #include <stddef.h>
 
 #include "invoke_ta.h"
+#include "ck_helpers.h"
 
 static const CK_FUNCTION_LIST libckteec_function_list = {
 	.version = {
@@ -26,18 +27,36 @@ static bool lib_initiated(void)
 
 CK_RV C_Initialize(CK_VOID_PTR pInitArgs)
 {
+	CK_RV rv = 0;
+
 	/* Argument currently unused as per the PKCS#11 specification */
 	(void)pInitArgs;
 
-	return ckteec_invoke_init();
+	rv = ckteec_invoke_init();
+
+	ASSERT_CK_RV(rv, CKR_ARGUMENTS_BAD, CKR_CANT_LOCK,
+		     CKR_CRYPTOKI_ALREADY_INITIALIZED, CKR_FUNCTION_FAILED,
+		     CKR_GENERAL_ERROR, CKR_HOST_MEMORY,
+		     CKR_NEED_TO_CREATE_THREADS, CKR_OK,
+		     CKR_MUTEX_BAD);
+
+	return rv;
 }
 
 CK_RV C_Finalize(CK_VOID_PTR pReserved)
 {
+	CK_RV rv = 0;
+
 	/* Argument currently unused as per the PKCS#11 specification */
 	(void)pReserved;
 
-	return ckteec_invoke_terminate();
+	rv = ckteec_invoke_terminate();
+
+	ASSERT_CK_RV(rv, CKR_ARGUMENTS_BAD, CKR_CRYPTOKI_NOT_INITIALIZED,
+		     CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY,
+		     CKR_OK);
+
+	return rv;
 }
 
 CK_RV C_GetInfo(CK_INFO_PTR pInfo)


### PR DESCRIPTION
For sanity of the library and service implementation, assert the
CKR_* return value before returning to caller from CK API functions.

This change asserts return values for C_Initialize() and C_Finalize().

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>