### PR TITLE
libckteec: correct ckteec_invoke_ta() prototype to handle output data size

### DIFF
--- a/libckteec/src/invoke_ta.h
+++ b/libckteec/src/invoke_ta.h
@@ -62,6 +62,27 @@ CK_RV ckteec_invoke_ta(unsigned long cmd, TEEC_SharedMemory *ctrl,
 		       TEEC_SharedMemory *io2, size_t *out2_size,
 		       TEEC_SharedMemory *io3, size_t *out3_size);
 
+static inline CK_RV ckteec_invoke_ctrl(unsigned long cmd,
+				       TEEC_SharedMemory *ctrl)
+{
+	return ckteec_invoke_ta(cmd, ctrl, NULL, NULL, NULL, NULL, NULL);
+}
+
+static inline CK_RV ckteec_invoke_ctrl_in(unsigned long cmd,
+					  TEEC_SharedMemory *ctrl,
+					  TEEC_SharedMemory *io1)
+{
+	return ckteec_invoke_ta(cmd, ctrl, io1, NULL, NULL, NULL, NULL);
+}
+
+static inline CK_RV ckteec_invoke_ctrl_out(unsigned long cmd,
+					   TEEC_SharedMemory *ctrl,
+					   TEEC_SharedMemory *io2,
+					   size_t *out_sz)
+{
+	return ckteec_invoke_ta(cmd, ctrl, NULL, io2, out_sz, NULL, NULL);
+}
+
 /*
  * ckteec_invoke_init - Initialize TEE session with the PKCS11 TA
  *

--- a/libckteec/src/invoke_ta.h
+++ b/libckteec/src/invoke_ta.h
@@ -49,15 +49,18 @@ void ckteec_free_shm(TEEC_SharedMemory *shm);
  *
  * @cmd - PKCS11 TA command ID
  * @ctrl - shared memory with serialized request input arguments or NULL
- * @io1 - In and/or out memory buffer argument #1 for the command or NULL
+ * @io1 - In memory buffer argument #1 for the command or NULL
  * @io2 - In and/or out memory buffer argument #2 for the command or NULL
+ * @out2_size - Reference to @io2 output buffer size or NULL if not applicable
  * @io3 - In and/or out memory buffer argument #3 for the command or NULL
+ * @out3_size - Reference to @io3 output buffer size or NULL if not applicable
  *
  * Return a CR_RV compliant return value
  */
 CK_RV ckteec_invoke_ta(unsigned long cmd, TEEC_SharedMemory *ctrl,
-		       TEEC_SharedMemory *io1, TEEC_SharedMemory *io2,
-		       TEEC_SharedMemory *io3);
+		       TEEC_SharedMemory *io1,
+		       TEEC_SharedMemory *io2, size_t *out2_size,
+		       TEEC_SharedMemory *io3, size_t *out3_size);
 
 /*
  * ckteec_invoke_init - Initialize TEE session with the PKCS11 TA


### PR DESCRIPTION
When invoking PKCS11 TA invocation parameters #2 and #3 can refer to output data buffer. This change adds means for caller to get the effective output data length.

An second commit defines helper function  `ckteec_invoke_*()` for invoking PKCS11 TA with reduced arguments.

