### PR TITLE
libckteec: Makefile: add missing dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-tee-supplicant: build-libteec
 
 build: build-libteec build-tee-supplicant build-libckteec
 
-build-libckteec:
+build-libckteec: build-libteec
 	@echo "Building libckteec.so"
 	@$(MAKE) --directory=libckteec --no-print-directory --no-builtin-variables
 


### PR DESCRIPTION
libckteec depends on libteec, therefore the build-libckteec target
needs to have build-libteec as a prerequisite.

Fixes the following build error:

 $ make -j`nproc`
 [...]
 <...>/bin/ld: cannot find -lteec
 collect2: error: ld returned 1 exit status
 Makefile:47: recipe for target '<...>/out/libckteec/libckteec.so.0.1.0' failed
 make[2]: *** [<...>/out/libckteec/libckteec.so.0.1.0] Error 1

Signed-off-by: Jerome Forissier <jerome@forissier.org>