### PR TITLE
ci: travis: Use proper construct for full clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
   - email: true
 
 git:
-  depth: 1000000
+  depth: false
 
 before_script:
   - export OPTEE_CLIENT=$PWD


### PR DESCRIPTION
As per the Travis docs at
https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth to
avoid performing git clones with limited depth, the depth should be set
to "false", not to a large magic number.

Signed-off-by: David Brown <david.brown@linaro.org>