### PR TITLE
libckteec: pkcs11 slot info

### DIFF
--- a/libckteec/CMakeLists.txt
+++ b/libckteec/CMakeLists.txt
@@ -20,6 +20,7 @@ set (SRC
 	src/ck_debug.c
 	src/ck_helpers.c
 	src/invoke_ta.c
+	src/pkcs11_token.c
 )
 
 ################################################################################

--- a/libckteec/Makefile
+++ b/libckteec/Makefile
@@ -25,6 +25,7 @@ LIBCKTEEC_SRCS		= pkcs11_api.c
 LIBCKTEEC_SRCS		+= ck_debug.c
 LIBCKTEEC_SRCS		+= ck_helpers.c
 LIBCKTEEC_SRCS		+= invoke_ta.c
+LIBCKTEEC_SRCS		+= pkcs11_token.c
 
 LIBCKTEEC_INCLUDES	= ${CURDIR}/include
 LIBCKTEEC_INCLUDES 	+= ${CURDIR}/../public

--- a/libckteec/include/pkcs11_ta.h
+++ b/libckteec/include/pkcs11_ta.h
@@ -54,18 +54,84 @@
  * Param#3 is currently unused and reserved for evolution of the API.
  */
 
-/*
- * PKCS11_CMD_PING		Acknowledge TA presence and return version info
- *
- * [in]         memref[0] = 32bit, unused, must be 0
- * [out]        memref[0] = 32bit return code, enum pkcs11_rc
- * [out]        memref[2] = [
- *                      32bit version major value,
- *                      32bit version minor value
- *                      32bit version patch value
- *              ]
- */
-#define PKCS11_CMD_PING				0
+enum pkcs11_ta_cmd {
+	/*
+	 * PKCS11_CMD_PING		Ack TA presence and return version info
+	 *
+	 * [in]  memref[0] = 32bit, unused, must be 0
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = [
+	 *              32bit version major value,
+	 *              32bit version minor value
+	 *              32bit version patch value
+	 *       ]
+	 */
+	PKCS11_CMD_PING = 0,
+
+	/*
+	 * PKCS11_CMD_SLOT_LIST - Get the table of the valid slot IDs
+	 *
+	 * [in]  memref[0] = 32bit, unused, must be 0
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = 32bit array slot_ids[slot counts]
+	 *
+	 * The TA instance may represent several PKCS#11 slots and
+	 * associated tokens. This commadn reports the IDs of embedded tokens.
+	 * This command relates the PKCS#11 API function C_GetSlotList().
+	 */
+	PKCS11_CMD_SLOT_LIST = 1,
+
+	/*
+	 * PKCS11_CMD_SLOT_INFO - Get cryptoki structured slot information
+	 *
+	 * [in]	 memref[0] = 32bit slot ID
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = (struct pkcs11_slot_info)info
+	 *
+	 * The TA instance may represent several PKCS#11 slots/tokens.
+	 * This command relates the PKCS#11 API function C_GetSlotInfo().
+	 */
+	PKCS11_CMD_SLOT_INFO = 2,
+
+	/*
+	 * PKCS11_CMD_TOKEN_INFO - Get cryptoki structured token information
+	 *
+	 * [in]	 memref[0] = 32bit slot ID
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = (struct pkcs11_token_info)info
+	 *
+	 * The TA instance may represent several PKCS#11 slots/tokens.
+	 * This command relates the PKCS#11 API function C_GetTokenInfo().
+	 */
+	PKCS11_CMD_TOKEN_INFO = 3,
+
+	/*
+	 * PKCS11_CMD_MECHANISM_IDS - Get list of the supported mechanisms
+	 *
+	 * [in]	 memref[0] = 32bit slot ID
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = 32bit array mechanism IDs
+	 *
+	 * This command relates to the PKCS#11 API function
+	 * C_GetMechanismList().
+	 */
+	PKCS11_CMD_MECHANISM_IDS = 4,
+
+	/*
+	 * PKCS11_CMD_MECHANISM_INFO - Get information on a specific mechanism
+	 *
+	 * [in]  memref[0] = [
+	 *              32bit slot ID,
+	 *              32bit mechanism ID (PKCS11_CKM_*)
+	 *       ]
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = (struct pkcs11_mechanism_info)info
+	 *
+	 * This command relates to the PKCS#11 API function
+	 * C_GetMechanismInfo().
+	 */
+	PKCS11_CMD_MECHANISM_INFO = 5,
+};
 
 /*
  * Command return codes
@@ -139,4 +205,80 @@ enum pkcs11_rc {
 	PKCS11_RV_NOT_FOUND			= 0x80000000,
 	PKCS11_RV_NOT_IMPLEMENTED		= 0x80000001,
 };
+
+/*
+ * Arguments for PKCS11_CMD_SLOT_INFO
+ */
+#define PKCS11_SLOT_DESC_SIZE			64
+#define PKCS11_SLOT_MANUFACTURER_SIZE		32
+#define PKCS11_SLOT_VERSION_SIZE		2
+
+struct pkcs11_slot_info {
+	uint8_t slot_description[PKCS11_SLOT_DESC_SIZE];
+	uint8_t manufacturer_id[PKCS11_SLOT_MANUFACTURER_SIZE];
+	uint32_t flags;
+	uint8_t hardware_version[PKCS11_SLOT_VERSION_SIZE];
+	uint8_t firmware_version[PKCS11_SLOT_VERSION_SIZE];
+};
+
+/*
+ * Values for pkcs11_slot_info::flags.
+ * PKCS11_CKFS_<x> reflects CryptoKi client API slot flags CKF_<x>.
+ */
+#define PKCS11_CKFS_TOKEN_PRESENT		(1U << 0)
+#define PKCS11_CKFS_REMOVABLE_DEVICE		(1U << 1)
+#define PKCS11_CKFS_HW_SLOT			(1U << 2)
+
+/*
+ * Arguments for PKCS11_CMD_TOKEN_INFO
+ */
+#define PKCS11_TOKEN_LABEL_SIZE			32
+#define PKCS11_TOKEN_MANUFACTURER_SIZE		32
+#define PKCS11_TOKEN_MODEL_SIZE			16
+#define PKCS11_TOKEN_SERIALNUM_SIZE		16
+
+struct pkcs11_token_info {
+	uint8_t label[PKCS11_TOKEN_LABEL_SIZE];
+	uint8_t manufacturer_id[PKCS11_TOKEN_MANUFACTURER_SIZE];
+	uint8_t model[PKCS11_TOKEN_MODEL_SIZE];
+	uint8_t serial_number[PKCS11_TOKEN_SERIALNUM_SIZE];
+	uint32_t flags;
+	uint32_t max_session_count;
+	uint32_t session_count;
+	uint32_t max_rw_session_count;
+	uint32_t rw_session_count;
+	uint32_t max_pin_len;
+	uint32_t min_pin_len;
+	uint32_t total_public_memory;
+	uint32_t free_public_memory;
+	uint32_t total_private_memory;
+	uint32_t free_private_memory;
+	uint8_t hardware_version[2];
+	uint8_t firmware_version[2];
+	uint8_t utc_time[16];
+};
+
+/*
+ * Values for pkcs11_token_info::flags.
+ * PKCS11_CKFT_<x> reflects CryptoKi client API token flags CKF_<x>.
+ */
+#define PKCS11_CKFT_RNG					(1U << 0)
+#define PKCS11_CKFT_WRITE_PROTECTED			(1U << 1)
+#define PKCS11_CKFT_LOGIN_REQUIRED			(1U << 2)
+#define PKCS11_CKFT_USER_PIN_INITIALIZED		(1U << 3)
+#define PKCS11_CKFT_RESTORE_KEY_NOT_NEEDED		(1U << 4)
+#define PKCS11_CKFT_CLOCK_ON_TOKEN			(1U << 5)
+#define PKCS11_CKFT_PROTECTED_AUTHENTICATION_PATH	(1U << 6)
+#define PKCS11_CKFT_DUAL_CRYPTO_OPERATIONS		(1U << 7)
+#define PKCS11_CKFT_TOKEN_INITIALIZED			(1U << 8)
+#define PKCS11_CKFT_USER_PIN_COUNT_LOW			(1U << 9)
+#define PKCS11_CKFT_USER_PIN_FINAL_TRY			(1U << 10)
+#define PKCS11_CKFT_USER_PIN_LOCKED			(1U << 11)
+#define PKCS11_CKFT_USER_PIN_TO_BE_CHANGED		(1U << 12)
+#define PKCS11_CKFT_SO_PIN_COUNT_LOW			(1U << 13)
+#define PKCS11_CKFT_SO_PIN_FINAL_TRY			(1U << 14)
+#define PKCS11_CKFT_SO_PIN_LOCKED			(1U << 15)
+#define PKCS11_CKFT_SO_PIN_TO_BE_CHANGED		(1U << 16)
+#define PKCS11_CKFT_ERROR_STATE				(1U << 17)
+
 #endif /*PKCS11_TA_H*/

--- a/libckteec/src/ck_helpers.h
+++ b/libckteec/src/ck_helpers.h
@@ -26,9 +26,4 @@ void ckteec_assert_expected_rv(const char *function, CK_RV rv,
 #define ASSERT_CK_RV(_rv, ...)		(void)0
 #endif /*DEBUG*/
 
-/*
- * Convert IDs between PKCS11 TA and Cryptoki.
- */
-CK_RV teec2ck_rv(TEEC_Result res);
-
 #endif /*LIBCKTEEC_CK_HELPERS_H*/

--- a/libckteec/src/local_utils.h
+++ b/libckteec/src/local_utils.h
@@ -8,4 +8,9 @@
 
 #define ARRAY_SIZE(array)	(sizeof(array) / sizeof(array[0]))
 
+#define COMPILE_TIME_ASSERT(x) \
+	do { \
+		switch (0) { case 0: case ((x) ? 1: 0) : default : break; } \
+	} while (0)
+
 #endif /*LIBCKTEEC_LOCAL_UTILS_H*/

--- a/libckteec/src/pkcs11_api.c
+++ b/libckteec/src/pkcs11_api.c
@@ -20,6 +20,7 @@ static const CK_FUNCTION_LIST libckteec_function_list = {
 	.C_Finalize = C_Finalize,
 	.C_GetInfo = C_GetInfo,
 	.C_GetFunctionList = C_GetFunctionList,
+	.C_GetSlotList = C_GetSlotList,
 };
 
 static bool lib_initiated(void)
@@ -90,14 +91,16 @@ CK_RV C_GetSlotList(CK_BBOOL tokenPresent,
 		    CK_SLOT_ID_PTR pSlotList,
 		    CK_ULONG_PTR pulCount)
 {
-	(void)tokenPresent;
-	(void)pSlotList;
-	(void)pulCount;
+	CK_RV rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (!lib_initiated())
-		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (lib_initiated())
+		rv = ck_slot_get_list(tokenPresent, pSlotList, pulCount);
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	ASSERT_CK_RV(rv, CKR_ARGUMENTS_BAD, CKR_BUFFER_TOO_SMALL,
+		     CKR_CRYPTOKI_NOT_INITIALIZED, CKR_FUNCTION_FAILED,
+		     CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK);
+
+	return rv;
 }
 
 CK_RV C_GetSlotInfo(CK_SLOT_ID slotID,

--- a/libckteec/src/pkcs11_api.c
+++ b/libckteec/src/pkcs11_api.c
@@ -9,6 +9,7 @@
 
 #include "invoke_ta.h"
 #include "ck_helpers.h"
+#include "pkcs11_token.h"
 
 static const CK_FUNCTION_LIST libckteec_function_list = {
 	.version = {
@@ -17,6 +18,7 @@ static const CK_FUNCTION_LIST libckteec_function_list = {
 	},
 	.C_Initialize = C_Initialize,
 	.C_Finalize = C_Finalize,
+	.C_GetInfo = C_GetInfo,
 	.C_GetFunctionList = C_GetFunctionList,
 };
 
@@ -61,12 +63,16 @@ CK_RV C_Finalize(CK_VOID_PTR pReserved)
 
 CK_RV C_GetInfo(CK_INFO_PTR pInfo)
 {
-	(void)pInfo;
+	CK_RV rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (!lib_initiated())
-		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (lib_initiated())
+		rv = ck_get_info(pInfo);
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	ASSERT_CK_RV(rv, CKR_ARGUMENTS_BAD, CKR_CRYPTOKI_NOT_INITIALIZED,
+		     CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY,
+		     CKR_OK);
+
+	return rv;
 }
 
 CK_RV C_GetFunctionList(CK_FUNCTION_LIST_PTR_PTR ppFunctionList)

--- a/libckteec/src/pkcs11_api.c
+++ b/libckteec/src/pkcs11_api.c
@@ -21,6 +21,7 @@ static const CK_FUNCTION_LIST libckteec_function_list = {
 	.C_GetInfo = C_GetInfo,
 	.C_GetFunctionList = C_GetFunctionList,
 	.C_GetSlotList = C_GetSlotList,
+	.C_GetSlotInfo = C_GetSlotInfo,
 };
 
 static bool lib_initiated(void)
@@ -106,13 +107,16 @@ CK_RV C_GetSlotList(CK_BBOOL tokenPresent,
 CK_RV C_GetSlotInfo(CK_SLOT_ID slotID,
 		    CK_SLOT_INFO_PTR pInfo)
 {
-	(void)slotID;
-	(void)pInfo;
+	CK_RV rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (!lib_initiated())
-		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (lib_initiated())
+		rv = ck_slot_get_info(slotID, pInfo);
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	ASSERT_CK_RV(rv, CKR_ARGUMENTS_BAD, CKR_CRYPTOKI_NOT_INITIALIZED,
+		     CKR_DEVICE_ERROR, CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR,
+		     CKR_HOST_MEMORY, CKR_OK, CKR_SLOT_ID_INVALID);
+
+	return rv;
 }
 
 CK_RV C_InitToken(CK_SLOT_ID slotID,

--- a/libckteec/src/pkcs11_token.c
+++ b/libckteec/src/pkcs11_token.c
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2017-2020, Linaro Limited
+ */
+
+#include <ck_debug.h>
+#include <pkcs11.h>
+#include <pkcs11_ta.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ck_helpers.h"
+#include "invoke_ta.h"
+#include "local_utils.h"
+#include "pkcs11_token.h"
+
+#define PKCS11_LIB_MANUFACTURER		"Linaro"
+#define PKCS11_LIB_DESCRIPTION		"OP-TEE PKCS11 Cryptoki library"
+
+/**
+ * ck_get_info - Get local information for C_GetInfo
+ */
+CK_RV ck_get_info(CK_INFO_PTR info)
+{
+	const CK_INFO lib_info = {
+		.cryptokiVersion =  {
+			CK_PKCS11_VERSION_MAJOR,
+			CK_PKCS11_VERSION_MINOR,
+		},
+		.manufacturerID = PKCS11_LIB_MANUFACTURER,
+		.flags = 0,		/* must be zero per the PKCS#11 2.40 */
+		.libraryDescription = PKCS11_LIB_DESCRIPTION,
+		.libraryVersion = {
+			PKCS11_TA_VERSION_MAJOR,
+			PKCS11_TA_VERSION_MINOR
+		},
+	};
+	int n = 0;
+
+	if (!info)
+		return CKR_ARGUMENTS_BAD;
+
+	*info = lib_info;
+
+	/* Pad strings with blank characters */
+	n = strnlen((char *)info->manufacturerID,
+		    sizeof(info->manufacturerID));
+	memset(&info->manufacturerID[n], ' ',
+	       sizeof(info->manufacturerID) - n);
+
+	n = strnlen((char *)info->libraryDescription,
+		    sizeof(info->libraryDescription));
+	memset(&info->libraryDescription[n], ' ',
+	       sizeof(info->libraryDescription) - n);
+
+	return CKR_OK;
+}

--- a/libckteec/src/pkcs11_token.h
+++ b/libckteec/src/pkcs11_token.h
@@ -15,4 +15,6 @@ CK_RV ck_get_info(CK_INFO_PTR info);
 CK_RV ck_slot_get_list(CK_BBOOL present,
 		       CK_SLOT_ID_PTR slots, CK_ULONG_PTR count);
 
+CK_RV ck_slot_get_info(CK_SLOT_ID slot, CK_SLOT_INFO_PTR info);
+
 #endif /*LIBCKTEEC_PKCS11_TOKEN_H*/

--- a/libckteec/src/pkcs11_token.h
+++ b/libckteec/src/pkcs11_token.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2017, Linaro Limited
+ */
+
+#ifndef LIBCKTEEC_PKCS11_TOKEN_H
+#define LIBCKTEEC_PKCS11_TOKEN_H
+
+#include <pkcs11.h>
+
+#include "invoke_ta.h"
+
+CK_RV ck_get_info(CK_INFO_PTR info);
+
+#endif /*LIBCKTEEC_PKCS11_TOKEN_H*/

--- a/libckteec/src/pkcs11_token.h
+++ b/libckteec/src/pkcs11_token.h
@@ -12,4 +12,7 @@
 
 CK_RV ck_get_info(CK_INFO_PTR info);
 
+CK_RV ck_slot_get_list(CK_BBOOL present,
+		       CK_SLOT_ID_PTR slots, CK_ULONG_PTR count);
+
 #endif /*LIBCKTEEC_PKCS11_TOKEN_H*/


### PR DESCRIPTION
Implement PKCS#11 API functions `C_GetInfo()`, `C_GetSlotList()` and `C_GetSlotInfo()`.

Related to P-R https://github.com/OP-TEE/optee_os/pull/3644.