### PR TITLE
libckteec: implement C_GetTokenInfo()

### DIFF
--- a/libckteec/src/pkcs11_api.c
+++ b/libckteec/src/pkcs11_api.c
@@ -22,6 +22,7 @@ static const CK_FUNCTION_LIST libckteec_function_list = {
 	.C_GetFunctionList = C_GetFunctionList,
 	.C_GetSlotList = C_GetSlotList,
 	.C_GetSlotInfo = C_GetSlotInfo,
+	.C_GetTokenInfo = C_GetTokenInfo,
 };
 
 static bool lib_initiated(void)
@@ -138,13 +139,18 @@ CK_RV C_InitToken(CK_SLOT_ID slotID,
 CK_RV C_GetTokenInfo(CK_SLOT_ID slotID,
 		     CK_TOKEN_INFO_PTR pInfo)
 {
-	(void)slotID;
-	(void)pInfo;
+	CK_RV rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (!lib_initiated())
-		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (lib_initiated())
+		rv = ck_token_get_info(slotID, pInfo);
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	ASSERT_CK_RV(rv, CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR,
+		     CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED, CKR_FUNCTION_FAILED,
+		     CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK,
+		     CKR_SLOT_ID_INVALID, CKR_TOKEN_NOT_PRESENT,
+		     CKR_TOKEN_NOT_RECOGNIZED, CKR_ARGUMENTS_BAD);
+
+	return rv;
 }
 
 CK_RV C_GetMechanismList(CK_SLOT_ID slotID,

--- a/libckteec/src/pkcs11_token.h
+++ b/libckteec/src/pkcs11_token.h
@@ -17,4 +17,6 @@ CK_RV ck_slot_get_list(CK_BBOOL present,
 
 CK_RV ck_slot_get_info(CK_SLOT_ID slot, CK_SLOT_INFO_PTR info);
 
+CK_RV ck_token_get_info(CK_SLOT_ID slot, CK_TOKEN_INFO_PTR info);
+
 #endif /*LIBCKTEEC_PKCS11_TOKEN_H*/


### PR DESCRIPTION
Implement C_GetTokenInfo() API function to retrieve information about
a token implemented by the PKCS11 TA.

Helper function ta2ck_token_info() converts token information data from
TA API into compliant Cryptoki API.

Depends on https://github.com/OP-TEE/optee_os/pull/3656.