### PR TITLE
tee-supplicant: cast to __u64 to avoid potential overflow

### DIFF
--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -505,7 +505,7 @@ static bool write_response(int fd, union tee_rpc_invoke *request)
 	data.buf_ptr = (uintptr_t)&request->send;
 	data.buf_len = sizeof(struct tee_iocl_supp_send_arg) +
 		       sizeof(struct tee_ioctl_param) *
-				request->send.num_params;
+				(__u64)request->send.num_params;
 	if (ioctl(fd, TEE_IOC_SUPPL_SEND, &data)) {
 		EMSG("TEE_IOC_SUPPL_SEND: %s", strerror(errno));
 		return false;


### PR DESCRIPTION
If request->send.num_params is assigned a large value, there could be
an overflow when computing data.buf_len. Cast to __u64 to avoid a
32-bit computation.

Signed-off-by: Jerome Forissier <jerome@forissier.org>