### PR TITLE
libckteec/libteec: move LFLAGS to end of call

### DIFF
--- a/libckteec/Makefile
+++ b/libckteec/Makefile
@@ -47,7 +47,7 @@ libckteec: $(OUT_DIR)/$(LIBCKTEEC_SO_LIBRARY)
 
 $(OUT_DIR)/$(LIBCKTEEC_SO_LIBRARY): $(LIBCKTEEC_OBJS)
 	@echo "  LINK    $@"
-	$(VPREFIX)$(CC) -shared -Wl,-soname,$(LIBCKTEEC_SO_LIBRARY) $(LIBCKTEEC_LFLAGS) -o $@ $+
+	$(VPREFIX)$(CC) -shared -Wl,-soname,$(LIBCKTEEC_SO_LIBRARY) -o $@ $+ $(LIBCKTEEC_LFLAGS)
 	@echo ""
 
 libckteec: $(OUT_DIR)/$(LIBCKTEEC_AR_LIBRARY)

--- a/libteec/Makefile
+++ b/libteec/Makefile
@@ -48,7 +48,7 @@ libteec: $(TEEC_LIBRARY) $(OUT_DIR)/libteec.a
 
 $(TEEC_LIBRARY): $(TEEC_OBJS)
 	@echo "  LINK    $@"
-	$(VPREFIX)$(CC) -shared -Wl,-soname,$(LIB_MAJOR) $(TEEC_LFLAGS) -o $@ $+
+	$(VPREFIX)$(CC) -shared -Wl,-soname,$(LIB_MAJOR) -o $@ $+ $(TEEC_LFLAGS)
 	@echo ""
 
 $(OUT_DIR)/libteec.a: $(TEEC_OBJS)


### PR DESCRIPTION
At least Yocto and ptxdist provide the option to invoke the linker with
-Wl,--as-needed, which will only mark the libraries as needed if they
are used by the binary or library. However this assumes that the object
files are passed before the shared libraries, move the LFLAGS for
libctkteec and libteec to the end of linker invocation to support this.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>