### PR TITLE
libteec: fix null pointer dereference

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -568,7 +568,7 @@ void TEEC_CloseSession(TEEC_Session *session)
 
 	memset(&arg, 0, sizeof(arg));
 
-	if (!session)
+	if (!session || !session->ctx)
 		return;
 
 	arg.session = session->session_id;
@@ -598,7 +598,7 @@ TEEC_Result TEEC_InvokeCommand(TEEC_Session *session, uint32_t cmd_id,
 	memset(&buf_data, 0, sizeof(buf_data));
 	memset(&shm, 0, sizeof(shm));
 
-	if (!session) {
+	if (!session || !session->ctx) {
 		eorig = TEEC_ORIGIN_API;
 		res = TEEC_ERROR_BAD_PARAMETERS;
 		goto out;
@@ -664,7 +664,7 @@ void TEEC_RequestCancellation(TEEC_Operation *operation)
 	session = operation->session;
 	teec_mutex_unlock(&teec_mutex);
 
-	if (!session)
+	if (!session || !session->ctx)
 		return;
 
 	arg.session = session->session_id;


### PR DESCRIPTION
The context of the given session which used to close a session
or invoke command may be NULL.
    
Typically, we would not call TEEC_InvokeCommand or TEEC_CloseSession
if TEEC_Opensession or TEEC_InitializeContext failed, but we can not
stop people from doing that either.
    
Actually we failed some test in our product which keep calling
`invokeCommand` even if `Opensession` has failed, and it finally turns
out a hang task because the `session->ctx` is NULL.
    
Signed-off-by: Xiao Wang <xiaowang3@huawei.com>
Tested-by: Xiao Wang <xiaowang3@huawei.com> (Hisilicon)
Signed-off-by: Hu Keping <hukeping@huawei.com>