### PR TITLE
libteec: report out of bound memory references from client library

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -271,6 +271,10 @@ static TEEC_Result teec_pre_process_partial(uint32_t param_type,
 	if ((shm->flags & req_shm_flags) != req_shm_flags)
 		return TEEC_ERROR_BAD_PARAMETERS;
 
+	if ((memref->offset + memref->size < memref->offset) ||
+	    (memref->offset + memref->size > shm->size))
+		return TEEC_ERROR_BAD_PARAMETERS;
+
 	/*
 	 * We're using a shadow buffer in this reference, copy the real buffer
 	 * into the shadow buffer if needed. We'll copy it back once we've


### PR DESCRIPTION
Change teec_pre_process_partial() to reject out of bound memref
invocation parameters before TEE is invoked.

This change is needed in case dynamic SHM is disabled in which case
memory reference used as TEE invocation parameters may have been
allocated using a wider buffer than the one provided by client. In
such case, TEE may not able to detect out of bound references
since original client buffer very location (start and size) do not
reach the TEE.

Reported-by: Sumit Garg <sumit.garg@linaro.org>
Suggested-by: Jens Wiklander <jens.wiklander@linaro.org>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>