### PR TITLE
libteec: registration shared memory for a null buffer is invalid

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -689,6 +689,9 @@ TEEC_Result TEEC_RegisterSharedMemory(TEEC_Context *ctx, TEEC_SharedMemory *shm)
 	if (!shm->flags || (shm->flags & ~(TEEC_MEM_INPUT | TEEC_MEM_OUTPUT)))
 		return TEEC_ERROR_BAD_PARAMETERS;
 
+	if (!shm->buffer)
+		return TEEC_ERROR_BAD_PARAMETERS;
+
 	s = shm->size;
 	if (!s)
 		s = 8;


### PR DESCRIPTION
Fix libteec to return TEEC_ERROR_BAD_PARAMETERS when client registers
a shared memory reference for a NULL buffer as per GPD specification
v1.0 that states "The buffer field MUST point to the memory region to
be shared, and MUST not be NULL.

Prior this change TEEC_RegisterSharedMemory() called with a NULL buffer
reference returned TEEC_ERROR_OUT_OF_MEMORY when dynamic shared memory
is enabled and successfully registered a memory reference when dynamic
shared memory is disabled. With this change the API function returns
TEEC_ERROR_BAD_PARAMETERS.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>