### PR TITLE
readme: update the link to optee_client documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ information that used to be here in this git can be found under [optee_client].
 
 // OP-TEE core maintainers
 
-[optee_client]: https://optee.readthedocs.io/building/gits/optee_client.html
+[optee_client]: https://optee.readthedocs.io/en/latest/building/gits/optee_client.html


### PR DESCRIPTION
This fixes a broken link.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>