### PR TITLE
libckteec: fix SONAME to be libckteec.so.<MAJOR_VERSION>

### DIFF
--- a/libckteec/CMakeLists.txt
+++ b/libckteec/CMakeLists.txt
@@ -1,6 +1,10 @@
 project(ckteec C)
 
-set(PROJECT_VERSION "0.1.0")
+set(MAJOR_VERSION 0)
+set(MINOR_VERSION 1)
+set(PATCH_VERSION 0)
+
+set(PROJECT_VERSION "${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}")
 
 ################################################################################
 # Packages
@@ -30,7 +34,7 @@ add_library (ckteec SHARED ${SRC})
 
 set_target_properties (ckteec PROPERTIES
 	VERSION ${PROJECT_VERSION}
-	SOVERSION ${PROJECT_NAME}
+	SOVERSION ${MAJOR_VERSION}
 )
 
 ################################################################################

--- a/libckteec/Makefile
+++ b/libckteec/Makefile
@@ -47,7 +47,7 @@ libckteec: $(OUT_DIR)/$(LIBCKTEEC_SO_LIBRARY)
 
 $(OUT_DIR)/$(LIBCKTEEC_SO_LIBRARY): $(LIBCKTEEC_OBJS)
 	@echo "  LINK    $@"
-	$(VPREFIX)$(CC) -shared -Wl,-soname,$(LIBCKTEEC_SO_LIBRARY) -o $@ $+ $(LIBCKTEEC_LFLAGS)
+	$(VPREFIX)$(CC) -shared -Wl,-soname,$(LIB_MAJOR) -o $@ $+ $(LIBCKTEEC_LFLAGS)
 	@echo ""
 
 libckteec: $(OUT_DIR)/$(LIBCKTEEC_AR_LIBRARY)


### PR DESCRIPTION
The libckteec CMakeList.txt and Makefile both have the SONAME wrong.
With the current version (0.1.0), SONAME should be libckteec.so.0, but:
- CMakeList.txt sets it to libckteec.so.ckteec
- Makefile sets it to libckteec.so.0.1.0

This commit fixes both build environments.

Reported-by: Guillaume Gardet <guillaume.gardet@opensuse.org>
Signed-off-by: Jerome Forissier <jerome@forissier.org>