### PR TITLE
libteec: fix TEEC_RegisterSharedMemory() with a fallback option

### DIFF
--- a/public/tee_client_api.h
+++ b/public/tee_client_api.h
@@ -298,7 +298,10 @@ typedef struct {
 	size_t alloced_size;
 	void *shadow_buffer;
 	int registered_fd;
-	bool buffer_allocated;
+	union {
+		bool dummy;
+		uint8_t flags;
+	} internal;
 } TEEC_SharedMemory;
 
 /**


### PR DESCRIPTION
Adds a fallback option to TEEC_RegisterSharedMemory() where
TEE_IOC_SHM_REGISTER fails, likely due to the caller supplying read-only
memory. Instead of failing and burden the caller to handle this,
implement it here instead. If TEE_IOC_SHM_REGISTER fails, malloc() a
buffer and register that as a shadow buffer instead.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>