### PR TITLE
libteec: Avoid memcpy when using TEEC_TempMemoryReference

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -900,19 +900,25 @@ void TEEC_ReleaseSharedMemory(TEEC_SharedMemory *shm)
 		return;
 
 	if (shm->shadow_buffer) {
-		if (shm->internal.flags & SHM_FLAG_SHADOW_BUFFER_ALLOCED)
-			free(shm->shadow_buffer);
-		else
+		if (shm->registered_fd >= 0) {
+			if (shm->internal.flags &
+			    SHM_FLAG_SHADOW_BUFFER_ALLOCED)
+				free(shm->shadow_buffer);
+			close(shm->registered_fd);
+		} else {
 			munmap(shm->shadow_buffer, shm->alloced_size);
+		}
 	} else if (shm->buffer) {
 		if (shm->registered_fd >= 0) {
 			if (shm->internal.flags & SHM_FLAG_BUFFER_ALLOCED)
 				free(shm->buffer);
 			close(shm->registered_fd);
-		} else
+		} else {
 			munmap(shm->buffer, shm->alloced_size);
-	} else if (shm->registered_fd >= 0)
+		}
+	} else if (shm->registered_fd >= 0) {
 		close(shm->registered_fd);
+	}
 
 	shm->id = -1;
 	shm->shadow_buffer = NULL;


### PR DESCRIPTION
When dynamic shared memory is enabled, use TEEC_RegisterSharedMemory
instead of TEE_AllocateSharedMemory when dealing with parameters of
type TEEC_TempMemoryReference. Earlier when dealing with such parameters,
a new temporary buffer was being allocated and then registered
as shared memory.  If the buffer passed by user can be registered
directly as shared memory, this allocation of temporary buffer is not
required. This helps in avoiding unnecessary memcpy. In case, there is
failure when trying to register the user passed buffer, we can fall back
to allocate memory path.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>