### PR TITLE
libteec: Handle NULL pointer when using TEEC_TempMemoryReference

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -202,13 +202,20 @@ static TEEC_Result teec_pre_process_tmpref(TEEC_Context *ctx,
 	}
 	shm->size = tmpref->size;
 
-	if (!tmpref->buffer && ctx->memref_null) {
+	if (!tmpref->buffer) {
 		if (tmpref->size)
 			return TEEC_ERROR_BAD_PARAMETERS;
 
-		/* Null pointer, indicate no shared memory attached */
-		MEMREF_SHM_ID(param) = TEE_MEMREF_NULL;
-		shm->id = -1;
+		if (ctx->memref_null) {
+			/* Null pointer, indicate no shared memory attached */
+			MEMREF_SHM_ID(param) = TEE_MEMREF_NULL;
+			shm->id = -1;
+		} else {
+			res = TEEC_AllocateSharedMemory(ctx, shm);
+			if (res != TEEC_SUCCESS)
+				return res;
+			MEMREF_SHM_ID(param) = shm->id;
+		}
 	} else {
 		shm->buffer = tmpref->buffer;
 		res = TEEC_RegisterSharedMemory(ctx, shm);


### PR DESCRIPTION
If TEE or TEE driver doesn't support the capability "TEE_GEN_CAP_MEMREF_NULL",
"memref_null" is not set in the TEEC_Context. In such cases, while
handling parameters of type TEEC_TempMemoryReference, a call to
TEEC_RegisterSharedMemory() will return an error for NULL pointers.
Using NULL pointer is a valid use case and should not result in errors.
Use TEEC_AllocateSharedMemory() to avoid errors in such cases.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>