### PR TITLE
tee-supplicant: make RPMB_EMU a conditional assignment

### DIFF
--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -3,8 +3,8 @@ include ../config.mk
 
 OUT_DIR := $(OO)/tee-supplicant
 
-# Emulate RPMB ioctl's
-RPMB_EMU	:= 1
+# Emulate RPMB ioctl's by default
+RPMB_EMU	?= 1
 
 .PHONY: all tee-supplicant clean
 


### PR DESCRIPTION
At the moment the RPMB_EMU variable in the Makefile uses a simple
assignment and unconditionally sets the variable.
Move it to a conditional assignment and allow people to override it
from the command line with:
CROSS_COMPILE=aarch64-linux-gnu- RPMB_EMU=0 make

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>