### PR TITLE
libteec: Fix the initial value of shm->id in teec_pre_process_operation()

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -325,6 +325,10 @@ static TEEC_Result teec_pre_process_operation(TEEC_Context *ctx,
 
 	memset(shms, 0, sizeof(TEEC_SharedMemory) *
 			TEEC_CONFIG_PAYLOAD_REF_COUNT);
+
+	for (n = 0; n < TEEC_CONFIG_PAYLOAD_REF_COUNT; n++)
+		shms[n].id = -1;
+
 	if (!operation) {
 		memset(params, 0, sizeof(struct tee_ioctl_param) *
 				  TEEC_CONFIG_PAYLOAD_REF_COUNT);


### PR DESCRIPTION
teec_pre_process_operation()  returns an error code of teec_pre_process_tmpref() directly when it failed (such as allocate a very large size of SHM). In this situation, the shm->id are still zero. It result in wrong error handling. When TEEC_ReleaseSharedMemory() is called in function teec_free_temp_refs(), it may 
close a wrong fd 0 since the shm->id is not -1 (the initial value is zero).