### PR TITLE
ci: travis: download checkpatch.pl from linux-next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_script:
 
   # Download checkpatch.pl
   - export KERNEL=$HOME/linux && mkdir -p $KERNEL/scripts && cd $KERNEL/scripts
-  - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl && chmod a+x checkpatch.pl
-  - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
+  - wget https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/plain/scripts/checkpatch.pl && chmod a+x checkpatch.pl
+  - wget https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/plain/scripts/spelling.txt
   - echo "invalid.struct.name" >const_structs.checkpatch
   - export PATH=$KERNEL/scripts/:$PATH
   - cd $OPTEE_CLIENT


### PR DESCRIPTION
Change the checkpatch URL from linux master to linux-next to
fix the following error and hopefully be more convenient in the
future:

 Global symbol "$gitroot" requires explicit package name [...]

This patch is similar to the one recently merged in optee_os [1].

Link: [1] https://github.com/OP-TEE/optee_os/commit/5d50cc958c9d
Signed-off-by: Jerome Forissier <jerome@forissier.org>