### PR TITLE
libckteec: replace { } initializer by { 0 }

### DIFF
--- a/libckteec/src/pkcs11_processing.c
+++ b/libckteec/src/pkcs11_processing.c
@@ -19,7 +19,7 @@ CK_RV ck_create_object(CK_SESSION_HANDLE session, CK_ATTRIBUTE_PTR attribs,
 		       CK_ULONG count, CK_OBJECT_HANDLE_PTR handle)
 {
 	CK_RV rv = CKR_GENERAL_ERROR;
-	struct serializer obj = { };
+	struct serializer obj = { 0 };
 	size_t ctrl_size = 0;
 	TEEC_SharedMemory *ctrl = NULL;
 	TEEC_SharedMemory *out_shm = NULL;
@@ -114,7 +114,7 @@ CK_RV ck_encdecrypt_init(CK_SESSION_HANDLE session,
 {
 	CK_RV rv = CKR_GENERAL_ERROR;
 	TEEC_SharedMemory *ctrl = NULL;
-	struct serializer obj = { };
+	struct serializer obj = { 0 };
 	uint32_t session_handle = session;
 	uint32_t key_handle = key;
 	size_t ctrl_size = 0;

--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -39,7 +39,7 @@ static CK_RV serialize_indirect_attribute(struct serializer *obj,
 	CK_ATTRIBUTE_PTR attr = NULL;
 	CK_ULONG count = 0;
 	CK_RV rv = CKR_GENERAL_ERROR;
-	struct serializer obj2 = { };
+	struct serializer obj2 = { 0 };
 
 	switch (attribute->type) {
 	/* These are serialized each separately */
@@ -263,7 +263,7 @@ static CK_RV serialize_mecha_aes_iv(struct serializer *obj,
 CK_RV serialize_ck_mecha_params(struct serializer *obj,
 				CK_MECHANISM_PTR mechanism)
 {
-	CK_MECHANISM mecha = { };
+	CK_MECHANISM mecha = { 0 };
 	CK_RV rv = CKR_GENERAL_ERROR;
 
 	memset(obj, 0, sizeof(*obj));

--- a/libckteec/src/serializer.c
+++ b/libckteec/src/serializer.c
@@ -14,7 +14,7 @@
 
 CK_RV init_serial_object(struct serializer *obj)
 {
-	struct pkcs11_object_head head = { };
+	struct pkcs11_object_head head = { 0 };
 
 	memset(obj, 0, sizeof(*obj));
 
@@ -23,7 +23,7 @@ CK_RV init_serial_object(struct serializer *obj)
 
 void finalize_serial_object(struct serializer *obj)
 {
-	struct pkcs11_object_head head = { };
+	struct pkcs11_object_head head = { 0 };
 
 	head.attrs_size = obj->size - sizeof(head);
 	head.attrs_count = obj->item_count;


### PR DESCRIPTION
Replace { } initializer by { 0 } to fix the following build failure with gcc 4.8:

```
libckteec/src/pkcs11_processing.c: In function 'ck_create_object':
libckteec/src/pkcs11_processing.c:22:9: error: missing initializer for field 'buffer' of 'struct serializer' [-Werror=missing-field-initializers]
  struct serializer obj = { };
         ^
```
Fixes: http://autobuild.buildroot.org/results/a3d663adb943aee814180f01d6e153b3309be962
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
Reviewed-by: Etienne Carriere <etienne.carriere@linaro.org>