### PR TITLE
Write of coverage data file in REE FS

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -53,6 +53,18 @@ CFG_TA_GPROF_SUPPORT ?= y
 #   to dump something
 CFG_FTRACE_SUPPORT ?= y
 
+# CFG_GCOV_SUPPORT
+#   Enable dumping coverage data, not used unless secure world decides
+#   to dump something
+CFG_GCOV_SUPPORT ?= y
+
+# CFG_TEE_CLIENT_COV_DIR
+#   Path to folder that will contain coverage data.
+#   This folder can be created with the required permission in an init
+#   script during boot, else it will be created by the tee-supplicant on
+#   first REE FS access.
+CFG_TEE_CLIENT_COV_DIR ?= $(CFG_TEE_FS_PARENT_PATH)/coverage
+
 # Default output directory.
 # May be absolute, or relative to the optee_client source directory.
 O               ?= out

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -7,6 +7,7 @@ option (CFG_TA_TEST_PATH "Enable tee-supplicant to load from test/debug path" OF
 option (RPMB_EMU "Enable tee-supplicant to emulate RPMB" ON)
 option (CFG_TA_GPROF_SUPPORT "Enable tee-supplicant support for TAs instrumented with gprof" ON)
 option (CFG_FTRACE_SUPPORT "Enable tee-supplicant support for TAs instrumented with ftrace" ON)
+option (CFG_GCOV_SUPPORT "Enable tee-supplicant support for coverage data" ON)
 
 set (CFG_TEE_SUPP_LOG_LEVEL "1" CACHE STRING "tee-supplicant log level")
 # FIXME: Question is, is this really needed? Should just use defaults from # GNUInstallDirs?
@@ -14,6 +15,8 @@ set (CFG_TEE_CLIENT_LOAD_PATH "/lib" CACHE STRING "Location of libteec.so")
 set (CFG_TEE_FS_PARENT_PATH "/data/tee" CACHE STRING "Location of TEE filesystem (secure storage)")
 # FIXME: Why do we have if defined(CFG_GP_SOCKETS) && CFG_GP_SOCKETS == 1 in the c-file?
 set (CFG_GP_SOCKETS "1" CACHE STRING "Enable GlobalPlatform Socket API support")
+
+set (CFG_TEE_CLIENT_COV_DIR "/data/tee/coverage" CACHE STRING "Location of coverage data")
 
 ################################################################################
 # Source files
@@ -34,6 +37,10 @@ endif()
 
 if (CFG_TA_GPROF_SUPPORT OR CFG_FTRACE_SUPPORT)
 	set (SRC ${SRC} src/prof.c)
+endif()
+
+if (CFG_GCOV_SUPPORT)
+	set (SRC ${SRC} src/coverage.c)
 endif()
 
 ################################################################################
@@ -77,6 +84,12 @@ endif()
 if (CFG_FTRACE_SUPPORT)
 	target_compile_definitions (${PROJECT_NAME}
 		PRIVATE -DCFG_FTRACE_SUPPORT)
+endif()
+
+if (CFG_GCOV_SUPPORT)
+	target_compile_definitions (${PROJECT_NAME}
+		PRIVATE -DCFG_GCOV_SUPPORT
+		PRIVATE -DCFG_TEE_CLIENT_COV_DIR=${CFG_TEE_CLIENT_COV_DIR})
 endif()
 
 ################################################################################

--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -31,6 +31,9 @@ endif
 ifneq (,$(filter y,$(CFG_TA_GPROF_SUPPORT) $(CFG_FTRACE_SUPPORT)))
 TEES_SRCS	+= prof.c
 endif
+ifeq ($(CFG_GCOV_SUPPORT),y)
+TEES_SRCS	+= coverage.c
+endif
 
 TEES_SRC_DIR	:= src
 TEES_OBJ_DIR	:= $(OUT_DIR)
@@ -63,6 +66,11 @@ endif
 
 ifeq ($(CFG_FTRACE_SUPPORT),y)
 TEES_CFLAGS	+= -DCFG_FTRACE_SUPPORT
+endif
+
+ifeq ($(CFG_GCOV_SUPPORT),y)
+TEES_CFLAGS	+= -DCFG_GCOV_SUPPORT \
+		   -DCFG_TEE_CLIENT_COV_DIR=\"$(CFG_TEE_CLIENT_COV_DIR)\"
 endif
 
 TEES_LFLAGS	+= -lpthread

--- a/tee-supplicant/src/coverage.c
+++ b/tee-supplicant/src/coverage.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 NXP
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <tee_client_api.h>
+#include <tee_supplicant.h>
+#include <teec_trace.h>
+
+#ifndef __aligned
+#define __aligned(x) __attribute__((__aligned__(x)))
+#endif
+#include <linux/tee.h>
+
+#include "tee_supp_fs.h"
+#include "coverage.h"
+
+#define MAX_PATH_SIZE 255
+
+static const char *s_storage_dir = CFG_TEE_CLIENT_COV_DIR"/";
+
+static void fldump(const char* desc, const uint8_t *buf, uint32_t size)
+{
+	uint32_t i;
+
+	printf("%s(%d): [", desc, size);
+	for (i = 0; i < size; i++)
+		printf("%.2x ", buf[i]);
+	printf("]\n");
+}
+
+TEEC_Result coverage_process(size_t num_params, struct tee_ioctl_param *params)
+{
+	char *filepath;
+	uint32_t filepath_size;
+	char *cov_data;
+	uint32_t cov_data_size;
+	char path[MAX_PATH_SIZE] = { 0 };
+	int n;
+	int fd = -1;
+	int bytes_written = 0;
+	int total_bytes_written = 0;
+	int cov_data_size_left = 0;
+	char *p;
+
+	/* Process RPC parameters */
+	if (num_params != 2 ||
+	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
+		TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT ||
+	    (params[1].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
+		TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT) {
+		EMSG("Invalid parameters\n");
+		return TEEC_ERROR_BAD_PARAMETERS;
+	}
+
+	filepath = tee_supp_param_to_va(params + 0);
+	if (!filepath) {
+		EMSG("Cannot retrieve filepath\n");
+		return TEEC_ERROR_BAD_PARAMETERS;
+	}
+	filepath_size = MEMREF_SIZE(params + 0);
+
+	cov_data = tee_supp_param_to_va(params + 1);
+	if (!cov_data) {
+		EMSG("Cannot retrieve coverage data");
+		return TEEC_ERROR_BAD_PARAMETERS;
+	}
+	cov_data_size = MEMREF_SIZE(params + 1);
+
+	/* Check the filepath is a string (null terminated) */
+	if (filepath[filepath_size - 1] != '\0') {
+		EMSG("filepath is not a null terminated string");
+		fldump("filpath", (const uint8_t *)filepath, filepath_size);
+		return TEEC_ERROR_BAD_PARAMETERS;
+	}
+
+	IMSG("Writing %d bytes of coverage data for %s", cov_data_size,
+	     filepath);
+
+	/* Create the path of the file */
+	n = snprintf(path, sizeof(path), "%s%s", s_storage_dir, filepath);
+	if (n < 0 || n >= MAX_PATH_SIZE) {
+		EMSG("Path too long");
+		return TEEC_ERROR_SHORT_BUFFER;
+	}
+
+	/* Create the path
+	 * The path includes the file of the name which is created as a
+	 * directory by mkpath so we temporly replace the last / by a null
+	 * terminator
+	 */
+	p = strrchr(path, '/');
+	if (!p) {
+		EMSG("Could not find a slash");
+		return TEEC_ERROR_GENERIC;
+	}
+	*p = '\0';
+
+	n = mkpath(path, 0775);
+	*p = '/';
+	if (n != 0) {
+		EMSG("failed to create path for [%s] err: %d", path, n);
+		return TEEC_ERROR_STORAGE_NOT_AVAILABLE;
+	}
+
+	/* Write the file */
+	fd = open(path, O_CREAT | O_EXCL | O_WRONLY, 0664);
+	if (fd < 0) {
+		EMSG("failed to open [%s] err: %d(%s)", path, errno,
+		     strerror(errno));
+		return TEEC_ERROR_STORAGE_NOT_AVAILABLE;
+	}
+
+	cov_data_size_left = cov_data_size;
+	do {
+		bytes_written = write(fd, cov_data, cov_data_size_left);
+		IMSG("bytes_written: %d", bytes_written);
+		if (bytes_written > 0) {
+			total_bytes_written += bytes_written;
+			cov_data_size_left -= bytes_written;
+		}
+	} while (bytes_written < 0 && errno == EINTR);
+	close(fd);
+
+	if (bytes_written < 0 || total_bytes_written != (int)cov_data_size) {
+		EMSG("Issue when writing, written %d/%d, err: %d(%s)",
+		     total_bytes_written, cov_data_size, errno,
+		     strerror(errno));
+		return TEEC_ERROR_GENERIC;
+	}
+
+	return TEEC_SUCCESS;
+}

--- a/tee-supplicant/src/coverage.h
+++ b/tee-supplicant/src/coverage.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 NXP
+ */
+
+#ifndef COVERAGE_H
+#define COVERAGE_H
+
+#ifndef __aligned
+#define __aligned(x) __attribute__((__aligned__(x)))
+#endif
+#include <linux/tee.h>
+
+#include <tee_client_api.h>
+
+#include <teec_trace.h>
+
+#if defined(CFG_GCOV_SUPPORT)
+
+TEEC_Result coverage_process(size_t num_params, struct tee_ioctl_param *params);
+
+#else
+
+static inline TEEC_Result coverage_process(size_t num_params,
+					   struct tee_ioctl_param *params)
+{
+	(void)num_params;
+	(void)params;
+
+	return TEEC_ERROR_NOT_SUPPORTED;
+}
+
+#endif /* CFG_GCOV_SUPPORT */
+
+#endif /* COVERAGE_H */

--- a/tee-supplicant/src/optee_msg_supplicant.h
+++ b/tee-supplicant/src/optee_msg_supplicant.h
@@ -183,6 +183,11 @@
  */
 #define OPTEE_MSG_RPC_CMD_FTRACE	11
 
+/*
+ * Code coverage support management commands
+ */
+#define OPTEE_MSG_RPC_CMD_GCOV		12
+
 
 /*
  * Define protocol for messages with .cmd == OPTEE_MSG_RPC_CMD_SOCKET

--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -91,7 +91,7 @@ static int do_mkdir(const char *path, mode_t mode)
 	return 0;
 }
 
-static int mkpath(const char *path, mode_t mode)
+int mkpath(const char *path, mode_t mode)
 {
 	int status = 0;
 	char *subpath = strdup(path);

--- a/tee-supplicant/src/tee_supp_fs.h
+++ b/tee-supplicant/src/tee_supp_fs.h
@@ -34,4 +34,6 @@ struct tee_ioctl_param;
 TEEC_Result tee_supp_fs_process(size_t num_params,
 				struct tee_ioctl_param *params);
 
+int mkpath(const char *path, mode_t mode);
+
 #endif

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -52,6 +52,7 @@
 #include <tee_supp_fs.h>
 #include <tee_supplicant.h>
 #include <unistd.h>
+#include <coverage.h>
 
 #include "optee_msg_supplicant.h"
 
@@ -635,6 +636,9 @@ static bool process_one_request(struct thread_arg *arg)
 		break;
 	case OPTEE_MSG_RPC_CMD_FTRACE:
 		ret = prof_process(num_params, params, "ftrace-");
+		break;
+	case OPTEE_MSG_RPC_CMD_GCOV:
+		ret = coverage_process(num_params, params);
 		break;
 	default:
 		EMSG("Cmd [0x%" PRIx32 "] not supported", func);


### PR DESCRIPTION
Allow to write a coverage date file generated at runtime from optee core in plaintext in REE FS.

It stores the data files in a subfolder which can be configured by the user. The write of a data file has two arguments:
- The place to write: Absolute path of the object file which is covered by the data file, it is used later when processing the coverage to have the note files from compilation along with the data files produced at runtime. 
- The buffer of data to write