### PR TITLE
libckteec: Allow 0 length input buffer  for update operations.

### DIFF
--- a/libckteec/src/pkcs11_processing.c
+++ b/libckteec/src/pkcs11_processing.c
@@ -252,12 +252,10 @@ CK_RV ck_encdecrypt_oneshot(CK_SESSION_HANDLE session,
 	memcpy(ctrl->buffer, &session_handle, sizeof(session_handle));
 
 	/* Shm io1: input data buffer */
-	if (in_len) {
-		in_shm = ckteec_register_shm(in, in_len, CKTEEC_SHM_IN);
-		if (!in_shm) {
-			rv = CKR_HOST_MEMORY;
-			goto bail;
-		}
+	in_shm = ckteec_register_shm(in, in_len, CKTEEC_SHM_IN);
+	if (!in_shm) {
+		rv = CKR_HOST_MEMORY;
+		goto bail;
 	}
 
 	/* Shm io2: output data buffer */
@@ -417,12 +415,10 @@ CK_RV ck_signverify_update(CK_SESSION_HANDLE session,
 	memcpy(ctrl->buffer, &session_handle, sizeof(session_handle));
 
 	/* Shm io1: input data */
-	if (in_len) {
-		in_shm = ckteec_register_shm(in, in_len, CKTEEC_SHM_IN);
-		if (!in_shm) {
-			rv = CKR_HOST_MEMORY;
-			goto bail;
-		}
+	in_shm = ckteec_register_shm(in, in_len, CKTEEC_SHM_IN);
+	if (!in_shm) {
+		rv = CKR_HOST_MEMORY;
+		goto bail;
 	}
 
 	rv = ckteec_invoke_ctrl_in(sign ? PKCS11_CMD_SIGN_UPDATE :


### PR DESCRIPTION
If a valid input buffer with size 0 is passed in an update
operation like C_SignUpdate()/C_VerifyUpdate()/C_EncryptUpdate()/
C_DecryptUpdate(), current implementation return error
CKR_BAD_ARGUMENTS. This is actually not an error scenario.
Ideally, we should not perform any cryptographic operation
and return CKR_OK if other parameters are valid. Hence register
a shared memory buffer in such scenarios also and pass it to the TA.

Suggested-by: Etienne Carriere <etienne.carriere@linaro.org>
Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>