### PR TITLE
tee-supplicant: add a framework for loadable plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ GPATH
 GRTAGS
 GTAGS
 /libs
-Makefile
 /obj
 out
 .project

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ distclean: clean
 
 copy_export: build
 	mkdir -p $(DESTDIR)$(SBINDIR) $(DESTDIR)$(LIBDIR) $(DESTDIR)$(INCLUDEDIR)
+	cp config.mk $(DESTDIR)/optee_client_config.mk
 	cp -a ${O}/libteec/libteec.so* $(DESTDIR)$(LIBDIR)
 	cp -a ${O}/libteec/libteec.a $(DESTDIR)$(LIBDIR)
 	cp ${O}/tee-supplicant/tee-supplicant $(DESTDIR)$(SBINDIR)

--- a/config.mk
+++ b/config.mk
@@ -33,6 +33,10 @@ CFG_TEE_CLIENT_LOG_FILE ?= $(CFG_TEE_FS_PARENT_PATH)/teec.log
 #   The location of the client library file.
 CFG_TEE_CLIENT_LOAD_PATH ?= /lib
 
+# CFG_TEE_PLUGIN_LOAD_PATH
+#   The location of the user plugins
+CFG_TEE_PLUGIN_LOAD_PATH ?= /usr/lib/tee-supplicant/plugins/
+
 # CFG_TA_TEST_PATH
 #   Enable the tee test path.  When enabled, the supplicant will try
 #   loading from a debug path before the regular path.  This allows test

--- a/public/tee_plugin_method.h
+++ b/public/tee_plugin_method.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2020, Open Mobile Platform LLC
+ */
+
+#ifndef TEE_PLUGIN_METHOD_H
+#define TEE_PLUGIN_METHOD_H
+
+#include <stddef.h>
+#include <tee_client_api.h>
+
+struct plugin_method {
+	const char *name; /* short friendly name of the plugin */
+	TEEC_UUID uuid;
+	TEEC_Result (*init)(void);
+	TEEC_Result (*invoke)(unsigned int cmd, unsigned int sub_cmd,
+			      void *data, size_t in_len, size_t *out_len);
+};
+
+#endif /* TEE_PLUGIN_METHOD_H */

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -14,6 +14,8 @@ set (CFG_TEE_CLIENT_LOAD_PATH "/lib" CACHE STRING "Location of libteec.so")
 set (CFG_TEE_FS_PARENT_PATH "/data/tee" CACHE STRING "Location of TEE filesystem (secure storage)")
 # FIXME: Why do we have if defined(CFG_GP_SOCKETS) && CFG_GP_SOCKETS == 1 in the c-file?
 set (CFG_GP_SOCKETS "1" CACHE STRING "Enable GlobalPlatform Socket API support")
+set (CFG_TEE_PLUGIN_LOAD_PATH "/usr/lib/tee-supplicant/plugins/" CACHE STRING "tee-supplicant's plugins path")
+set (CMAKE_INSTALL_RPATH "${CFG_TEE_PLUGIN_LOAD_PATH}")
 
 ################################################################################
 # Source files
@@ -26,6 +28,7 @@ set (SRC
 	src/tee_supp_fs.c
 	src/tee_supplicant.c
 	src/teec_ta_load.c
+	src/plugin.c
 )
 
 if (CFG_GP_SOCKETS)
@@ -49,6 +52,7 @@ target_compile_definitions (${PROJECT_NAME}
 	PRIVATE -DTEEC_LOAD_PATH="${CFG_TEE_CLIENT_LOAD_PATH}"
 	PRIVATE -DTEE_FS_PARENT_PATH="${CFG_TEE_FS_PARENT_PATH}"
 	PRIVATE -DBINARY_PREFIX="TSUP"
+	PRIVATE -DTEE_PLUGIN_LOAD_PATH="${CFG_TEE_PLUGIN_LOAD_PATH}"
 )
 
 ################################################################################
@@ -86,7 +90,8 @@ target_include_directories(${PROJECT_NAME} PRIVATE src)
 
 target_link_libraries (${PROJECT_NAME}
 	PRIVATE teec
-	PRIVATE optee-client-headers)
+	PRIVATE optee-client-headers
+	PRIVATE dl)
 
 ################################################################################
 # Install targets

--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -18,7 +18,8 @@ TEES_SRCS	:= tee_supplicant.c \
 		   teec_ta_load.c \
 		   tee_supp_fs.c \
 		   rpmb.c \
-		   handle.c
+		   handle.c \
+		   plugin.c
 
 
 ifeq ($(CFG_GP_SOCKETS),y)
@@ -43,7 +44,8 @@ TEES_CFLAGS	:= $(addprefix -I, $(TEES_INCLUDES)) $(CFLAGS) \
 		   -DDEBUGLEVEL_$(CFG_TEE_SUPP_LOG_LEVEL) \
 		   -DBINARY_PREFIX=\"TEES\" \
 		   -DTEE_FS_PARENT_PATH=\"$(CFG_TEE_FS_PARENT_PATH)\" \
-		   -DTEEC_LOAD_PATH=\"$(CFG_TEE_CLIENT_LOAD_PATH)\"
+		   -DTEEC_LOAD_PATH=\"$(CFG_TEE_CLIENT_LOAD_PATH)\" \
+		   -DTEE_PLUGIN_LOAD_PATH=\"$(CFG_TEE_PLUGIN_LOAD_PATH)\"
 
 ifeq ($(CFG_GP_SOCKETS),y)
 TEES_CFLAGS	+= -DCFG_GP_SOCKETS=1
@@ -68,6 +70,10 @@ endif
 TEES_LFLAGS	+= -lpthread
 # Needed to get clock_gettime() for for glibc versions before 2.17
 TEES_LFLAGS	+= -lrt
+# Needed to dynamically load user plugins
+TEES_LFLAGS	+= -ldl
+# Needed for dlopen()
+TEES_LFLAGS += -Wl,-rpath=$(CFG_TEE_PLUGIN_LOAD_PATH)
 
 tee-supplicant: $(TEES_FILE)
 

--- a/tee-supplicant/src/optee_msg_supplicant.h
+++ b/tee-supplicant/src/optee_msg_supplicant.h
@@ -183,6 +183,10 @@
  */
 #define OPTEE_MSG_RPC_CMD_FTRACE	11
 
+/*
+ * Plugin commands
+ */
+#define OPTEE_MSG_RPC_CMD_PLUGIN	12
 
 /*
  * Define protocol for messages with .cmd == OPTEE_MSG_RPC_CMD_SOCKET
@@ -257,6 +261,40 @@
 
 /*
  * End of definitions for messages with .cmd == OPTEE_MSG_RPC_CMD_SOCKET
+ */
+
+/*
+ * Define protocol for messages with .cmd == OPTEE_MSG_RPC_CMD_PLUGIN
+ */
+
+/*
+ * Invoke a tee-supplicant plugin.
+ *
+ * [in]     param[0].u.value.a	OPTEE_INVOKE_PLUGIN
+ * [in]     param[0].u.value.b	uuid.d1
+ * [in]     param[0].u.value.c	uuid.d2
+ * [in]     param[1].u.value.a	uuid.d3
+ * [in]     param[1].u.value.b	uuid.d4
+ * [in]     param[1].u.value.c	cmd for plugin
+ * [in]     param[2].u.value.a	sub_cmd for plugin
+ * [out]    param[2].u.value.b  length of the outbuf (param[3]),
+ *                              if out is needed.
+ * [in/out] param[3].u.tmem	buffer holding data for plugin
+ *
+ * UUID serialized into octets:
+ * b0  b1  b2  b3   b4  b5  b6  b7   b8  b9  b10  b11   b12  b13  b14  b15
+ *       d1       |       d2       |        d3        |         d4
+ *
+ * The endianness of words d1, d2, d3 and d4 from SWd is little-endian.
+ * d1 word contains [b3 b2 b1 b0]
+ * d2 word contains [b7 b6 b5 b4]
+ * d3 word contains [b11 b10 b9 b8]
+ * d4 word contains [b15 b14 b13 b12]
+ */
+#define OPTEE_INVOKE_PLUGIN	0
+
+/*
+ * End of definitions for messages with .cmd == OPTEE_MSG_RPC_CMD_PLUGIN
  */
 
 #endif /*__OPTEE_MSG_SUPPLICANT_H*/

--- a/tee-supplicant/src/plugin.c
+++ b/tee-supplicant/src/plugin.c
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020, Open Mobile Platform LLC
+ */
+
+#include <assert.h>
+#include <ctype.h>
+#include <dlfcn.h>
+#include <dirent.h>
+#include <plugin.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tee_client_api.h>
+#include <teec_trace.h>
+#include <tee_supplicant.h>
+
+#include "optee_msg_supplicant.h"
+
+#ifndef __aligned
+#define __aligned(x) __attribute__((__aligned__(x)))
+#endif
+#include <linux/tee.h>
+
+/* internal possible returned values */
+enum plugin_err {
+	PLUGIN_OK = 0,
+	PLUGIN_DL_OPEN_ERR = -1,
+	PLUGIN_DL_SYM_ERR = -2,
+};
+
+static struct plugin *plugin_list_head;
+
+/* returns 0, if u1 and u2 are equal */
+static int uuid_cmp(TEEC_UUID *u1, TEEC_UUID *u2)
+{
+	if (!memcmp(u1, u2, sizeof(TEEC_UUID)))
+		return 0;
+
+	return 1;
+}
+
+static void uuid_from_octets(TEEC_UUID *d, const uint8_t s[TEE_IOCTL_UUID_LEN])
+{
+	d->timeLow = ((uint32_t)s[0] << 24) | ((uint32_t)s[1] << 16) |
+		((uint32_t)s[2] << 8) | s[3];
+	d->timeMid = ((uint32_t)s[4] << 8) | s[5];
+	d->timeHiAndVersion = ((uint32_t)s[6] << 8) | s[7];
+	memcpy(d->clockSeqAndNode, s + 8, sizeof(d->clockSeqAndNode));
+}
+
+static void push_plugin(struct plugin *p)
+{
+	p->next = plugin_list_head;
+	plugin_list_head = p;
+}
+
+static struct plugin *find_plugin(TEEC_UUID *u)
+{
+	struct plugin *p = plugin_list_head;
+
+	while (p) {
+		if (!uuid_cmp(&p->method->uuid, u))
+			return p;
+
+		p = p->next;
+	}
+
+	return NULL;
+}
+
+static enum plugin_err load_plugin(const char *name, struct plugin *p)
+{
+	void *handle = NULL;
+	struct plugin_method *m = NULL;
+
+	handle = dlopen(name, RTLD_LAZY);
+	if (!handle)
+		return PLUGIN_DL_OPEN_ERR;
+
+	p->handle = handle;
+
+	m = (struct plugin_method *)dlsym(handle, "plugin_method");
+	if (!m || !m->name || !m->invoke)
+		return PLUGIN_DL_SYM_ERR;
+
+	p->method = m;
+
+	return PLUGIN_OK;
+}
+
+static TEEC_Result plugin_invoke(TEEC_UUID *u, unsigned int cmd,
+				 unsigned int sub_cmd, void *data,
+				 size_t in_len, size_t *out_len)
+{
+	struct plugin *p = NULL;
+
+	p = find_plugin(u);
+	if (!p)
+		return TEEC_ERROR_ITEM_NOT_FOUND;
+
+	assert(p->method->invoke);
+
+	return p->method->invoke(cmd, sub_cmd, data, in_len, out_len);
+}
+
+TEEC_Result plugin_load_all(void)
+{
+	DIR *dir = NULL;
+	enum plugin_err res = PLUGIN_OK;
+	TEEC_Result teec_res = TEEC_SUCCESS;
+	struct dirent *entry = NULL;
+
+	dir = opendir(TEE_PLUGIN_LOAD_PATH);
+	if (!dir) {
+		IMSG("could not open directory %s", TEE_PLUGIN_LOAD_PATH);
+
+		/* don't generate error if there is no the dir */
+		return TEEC_SUCCESS;
+	}
+
+	while ((entry = readdir(dir))) {
+		if (entry->d_type == DT_REG) {
+			struct plugin *p;
+
+			p = calloc(1, sizeof(struct plugin));
+			if (!p) {
+				EMSG("allocate mem for plugin <%s> failed",
+				     entry->d_name);
+				closedir(dir);
+				return TEEC_ERROR_OUT_OF_MEMORY;
+			}
+
+			res = load_plugin((const char *)entry->d_name, p);
+			switch (res) {
+			case PLUGIN_DL_OPEN_ERR:
+				EMSG("open plugin <%s> failed: %s",
+				     entry->d_name, dlerror());
+				free(p);
+				continue;
+			case PLUGIN_DL_SYM_ERR:
+				EMSG("find 'plugin_method' sym in <%s> failed: %s",
+				     entry->d_name, dlerror());
+				free(p);
+				continue;
+			default:
+				DMSG("loading the <%s> plugin were successful",
+				     p->method->name);
+				break;
+			}
+
+			/* Init the plugin */
+			if (p->method->init) {
+				teec_res = p->method->init();
+				if (teec_res) {
+					EMSG("init the <%s> plugin failed with 0x%x",
+					     p->method->name, teec_res);
+					free(p);
+					continue;
+				}
+			}
+
+			push_plugin(p);
+		}
+	}
+
+	closedir(dir);
+	return TEEC_SUCCESS;
+}
+
+TEEC_Result plugin_process(size_t num_params, struct tee_ioctl_param *params)
+{
+	unsigned int cmd = 0;
+	unsigned int sub_cmd = 0;
+	void *data = NULL;
+	uint32_t data_len = 0;
+	TEEC_UUID uuid = { };
+	uint32_t uuid_words[4] = { };
+	size_t outlen = 0;
+	TEEC_Result res = TEEC_ERROR_NOT_SUPPORTED;
+
+	if (num_params != 4 ||
+	    (params[0].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
+		    TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INPUT ||
+	    (params[1].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
+		    TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INPUT ||
+	    (params[2].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
+		    TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INOUT ||
+	    (params[3].attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) !=
+		    TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INOUT)
+		return TEEC_ERROR_BAD_PARAMETERS;
+
+	uuid_words[0] = params[0].b;
+	uuid_words[1] = params[0].c;
+	uuid_words[2] = params[1].a;
+	uuid_words[3] = params[1].b;
+
+	uuid_from_octets(&uuid, (const uint8_t *)uuid_words);
+
+	cmd = params[1].c;
+	sub_cmd = params[2].a;
+
+	data = tee_supp_param_to_va(params + 3);
+	data_len = MEMREF_SIZE(params + 3);
+
+	if (data_len && !data)
+		return TEEC_ERROR_BAD_PARAMETERS;
+
+	switch (params[0].a) {
+	case OPTEE_INVOKE_PLUGIN:
+		res = plugin_invoke(&uuid, cmd, sub_cmd, data, data_len,
+				    &outlen);
+		params[2].b = outlen;
+	default:
+		break;
+	}
+
+	return res;
+}

--- a/tee-supplicant/src/plugin.h
+++ b/tee-supplicant/src/plugin.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2020, Open Mobile Platform LLC
+ */
+
+#ifndef PLUGIN_H
+#define PLUGIN_H
+
+#include <stdint.h>
+#include <tee_client_api.h>
+#include <tee_plugin_method.h>
+
+struct tee_ioctl_param;
+
+/* This structure describes one plugin for the supplicant */
+struct plugin {
+	void *handle;
+	struct plugin_method *method; /* Implemented in the plugin */
+	struct plugin *next;
+};
+
+/*
+ * Loads all shared objects from 'CFG_TEE_PLUGIN_LOAD_PATH'
+ * and binds all functions.
+ *
+ * @return 'TEEC_SUCCESS' if all plugins were successfully loaded.
+ */
+TEEC_Result plugin_load_all(void);
+
+/* Plugin RPC handler */
+TEEC_Result plugin_process(size_t num_params, struct tee_ioctl_param *params);
+
+#endif /* PLUGIN_H */
+

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -33,6 +33,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <prof.h>
+#include <plugin.h>
 #include <pthread.h>
 #include <rpmb.h>
 #include <stdbool.h>
@@ -636,6 +637,9 @@ static bool process_one_request(struct thread_arg *arg)
 	case OPTEE_MSG_RPC_CMD_FTRACE:
 		ret = prof_process(num_params, params, "ftrace-");
 		break;
+	case OPTEE_MSG_RPC_CMD_PLUGIN:
+		ret = plugin_process(num_params, params);
+		break;
 	default:
 		EMSG("Cmd [0x%" PRIx32 "] not supported", func);
 		/* Not supported. */
@@ -708,6 +712,11 @@ int main(int argc, char *argv[])
 
 	if (daemonize && daemon(0, 0) < 0) {
 		EMSG("daemon(): %s", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	if (plugin_load_all() != 0) {
+		EMSG("failed to load plugins");
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
This framework makes the supplicant a bit more flexible
in terms of providing services. Any external TEE services
can be designed as a tee-supplicant plugin.
It makes it easy to:
 - add new features in the supplicant that aren't needed in upstream,
   e.g. Rich OS specific services;
 - sync upstream version with own fork;

To create a plugin developers should implement the
'struct plugin_method' and a bind function.
See public/tee_plugin_method.h file.
As an example this patch implements a 'syslog' plugin
and its Makefile. The plugin helps to log any
information from TEE to system journal.

The plugin framework is based on new RPC call - 'OPTEE_MSG_RPC_CMD_PLUGIN'.
This RPC is an unified interface between TEE and any plugins.
Every plugin has own name based on UUID. TEE has access to
plugins only by the name (UUID).

Every plugin should be placed into "/usr/lib/tee-supplicant/plugins/".
The supplicant opens and binds all plugins in the directory during
startup process using libdl. After this any requests to plugins
from TEE will be processed in the common RPC handler.

Signed-off-by: Aleksandr Anisimov <a.anisimov@omprussia.ru>