### PR TITLE
libckteec: Serialization fixes

### DIFF
--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -293,12 +293,14 @@ CK_RV deserialize_ck_attributes(uint8_t *in, CK_ATTRIBUTE_PTR attributes,
 		struct pkcs11_attribute_head *cli_ref = (void *)curr_head;
 
 		len = sizeof(*cli_ref);
-		/*
-		 * Can't trust size because it was set to reflect
-		 * required buffer.
-		 */
-		if (cur_attr->pValue)
-			len += cli_ref->size;
+
+		/* Advance by size provisioned in input serialized buffer */
+		if (cur_attr->pValue) {
+			if (ck_attr_is_ulong(cur_attr->type))
+				len += sizeof(uint32_t);
+			else
+				len += cur_attr->ulValueLen;
+		}
 
 		rv = deserialize_ck_attribute(cli_ref, cur_attr);
 		if (rv)

--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -248,30 +248,31 @@ static CK_RV deserialize_ck_attribute(struct pkcs11_attribute_head *in,
 
 	/* Specific ulong encoded as 32bit in PKCS11 TA API */
 	if (ck_attr_is_ulong(out->type)) {
-		if (out->ulValueLen != sizeof(CK_ULONG))
+		if (out->ulValueLen < sizeof(CK_ULONG))
 			return CKR_ATTRIBUTE_TYPE_INVALID;
 
 		memcpy(&pkcs11_data32, in->data, sizeof(uint32_t));
+		ck_ulong = pkcs11_data32;
+		memcpy(out->pValue, &ck_ulong, sizeof(CK_ULONG));
+		out->ulValueLen = sizeof(CK_ULONG);
+		return CKR_OK;
 	}
 
 	switch (out->type) {
-	case CKA_CLASS:
-	case CKA_KEY_TYPE:
-	case CKA_KEY_GEN_MECHANISM:
-		ck_ulong = pkcs11_data32;
-		memcpy(out->pValue, &ck_ulong, sizeof(CK_ULONG));
-		break;
 	case CKA_WRAP_TEMPLATE:
 	case CKA_UNWRAP_TEMPLATE:
 		rv = deserialize_indirect_attribute(in, out->pValue);
 		break;
 	case CKA_ALLOWED_MECHANISMS:
 		rv = deserialize_mecha_list(out->pValue, in->data,
-					    out->ulValueLen / sizeof(CK_ULONG));
+					    in->size / sizeof(uint32_t));
+		out->ulValueLen = in->size / sizeof(uint32_t) *
+				  sizeof(CK_ULONG);
 		break;
 	/* Attributes which data value do not need conversion (aside ulong) */
 	default:
 		memcpy(out->pValue, in->data, in->size);
+		out->ulValueLen = in->size;
 		break;
 	}
 

--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -238,6 +238,11 @@ static CK_RV deserialize_ck_attribute(struct pkcs11_attribute_head *in,
 
 	out->type = in->id;
 
+	if (in->size == PKCS11_CK_UNAVAILABLE_INFORMATION) {
+		out->ulValueLen = CK_UNAVAILABLE_INFORMATION;
+		return CKR_OK;
+	}
+
 	if (out->ulValueLen < in->size) {
 		out->ulValueLen = in->size;
 		return CKR_OK;


### PR DESCRIPTION
Serialization fixes for passing non-aligned data element addresses and larger return buffers.
