### PR TITLE
libckteec: serialize: fix check for ULONG type entries

### DIFF
--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -155,7 +155,7 @@ static CK_RV serialize_ck_attribute(struct serializer *obj, CK_ATTRIBUTE *attr)
 		if (ck_attr_is_ulong(attr->type)) {
 			CK_ULONG ck_ulong = 0;
 
-			if (attr->ulValueLen != sizeof(CK_ULONG))
+			if (attr->ulValueLen < sizeof(CK_ULONG))
 				return CKR_ATTRIBUTE_TYPE_INVALID;
 
 			memcpy(&ck_ulong, attr->pValue, sizeof(ck_ulong));


### PR DESCRIPTION
It is fine for callee to allocate more memory than what is
needed for any attribute. Earlier for attributes of type
ulong, a strict check was there which returned error
if callee passed buffer greater than the required size.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>