### PR TITLE
libckteec: serialize: Fix crash with NULL pValue in attribute

### DIFF
--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -195,7 +195,11 @@ static CK_RV serialize_ck_attribute(struct serializer *obj, CK_ATTRIBUTE *attr)
 			pkcs11_size = sizeof(uint32_t);
 		} else {
 			pkcs11_pdata = attr->pValue;
-			pkcs11_size = attr->ulValueLen;
+			/* Support NULL data pointer with non-zero size */
+			if (!pkcs11_pdata)
+				pkcs11_size = 0;
+			else
+				pkcs11_size = attr->ulValueLen;
 		}
 		break;
 	}


### PR DESCRIPTION
An attribute template (type, pValue, ulValueLen) provided with
C_GetAttributeValue() may have pValue field as NULL pointer with
a zero/non-zero ulValueLen field. In these cases TEE should modify
the ulValueLen to hold the exact length of the specified attribute
for the object.

In the current code, for non-zero ulValueLen with pValue as NULL
pointer, an attempt was being made to read the ulValueLen length
data from NULL pointer resulting in segmentation fault. To fix this,
in such scenarios, pass ulValueLen as 0 to TEE.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>