### PR TITLE
libckteec: add missing include for gid_t

### DIFF
--- a/libckteec/src/invoke_ta.c
+++ b/libckteec/src/invoke_ta.c
@@ -15,6 +15,7 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <tee_client_api.h>
 #include <teec_trace.h>
 


### PR DESCRIPTION
Fixes the following build error by including `sys/types.h` to ensure `gid_t` is defined:
```text
[ 65%] Building C object libckteec/CMakeFiles/ckteec.dir/src/invoke_ta.c.o
src/invoke_ta.c: In function ‘ckteec_invoke_init’:
src/invoke_ta.c:245:2: error: unknown type name ‘gid_t’; did you mean ‘pid_t’?
  245 |  gid_t login_gid = 0;
      |  ^~~~~
      |  pid_t
src/invoke_ta.c:267:38: error: ‘gid_t’ undeclared (first use in this function); did you mean ‘pid_t’?
  267 |    if (errno == ERANGE || tmpconv > (gid_t)-1 ||
      |                                      ^~~~~
      |                                      pid_t
src/invoke_ta.c:267:38: note: each undeclared identifier is reported only once for each function it appears in
src/invoke_ta.c:274:23: error: expected ‘;’ before ‘tmpconv’
  274 |    login_gid = (gid_t)tmpconv;
      |                       ^~~~~~~
      |                       ;
libckteec/CMakeFiles/ckteec.dir/build.make:134: recipe for target 'libckteec/CMakeFiles/ckteec.dir/src/invoke_ta.c.o' failed
```

Signed-off-by: George Hopkins <george-hopkins@null.net>