### PR TITLE
tee-supplicant: daemonize before opening a supplicant device

### DIFF
--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -696,6 +696,11 @@ int main(int argc, char *argv[])
 			dev = argv[i];
 	}
 
+	if (daemonize && daemon(0, 0) < 0) {
+		EMSG("daemon(): %s", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
 	if (dev) {
 		arg.fd = open_dev(dev, &arg.gen_caps);
 		if (arg.fd < 0) {
@@ -708,11 +713,6 @@ int main(int argc, char *argv[])
 			EMSG("failed to find an OP-TEE supplicant device");
 			exit(EXIT_FAILURE);
 		}
-	}
-
-	if (daemonize && daemon(0, 0) < 0) {
-		EMSG("daemon(): %s", strerror(errno));
-		exit(EXIT_FAILURE);
 	}
 
 	if (plugin_load_all() != 0) {


### PR DESCRIPTION
Prior to this change tee-supplicant, when called with -d,
first opened /dev/teeprivX, and called daemon(3) later.
This implied that a file descriptor associated with the
supplicant device transferred from one process to another.

This may conflict with security policies related to tee device
file descriptors. Since TEE client ID is tied to a process,
transferring such a sensitive thing as a tee device handle
between processes might be discouraged.

Reorder the two: first daemonize, and open the tee device later.

---

An example of how such a security policy could be implemented can be seen at https://github.com/parport0/linux/tree/tee-fd.