### PR TITLE
libckteec: Add support for digest operations

### DIFF
--- a/libckteec/include/pkcs11_ta.h
+++ b/libckteec/include/pkcs11_ta.h
@@ -581,6 +581,22 @@ enum pkcs11_ta_cmd {
 	 * This command relates to the PKCS#11 API function C_DeriveKey().
 	 */
 	PKCS11_CMD_DERIVE_KEY = 43,
+
+	/*
+	 * PKCS11_CMD_RELEASE_ACTIVE_PROCESSING - Release active processing
+	 *
+	 * [in]  memref[0] = [
+	 *              32bit session handle,
+	 *              32bit enum pkcs11_ta_cmd
+	 *       ]
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 *
+	 * This command is used to release active processing in case of
+	 * Cryptoki API invocation error is detected in user space processing.
+	 * Function derived from pkcs11_ta_cmd is used to verify that active
+	 * processing matches.
+	 */
+	PKCS11_CMD_RELEASE_ACTIVE_PROCESSING = 44,
 };
 
 /*

--- a/libckteec/include/pkcs11_ta.h
+++ b/libckteec/include/pkcs11_ta.h
@@ -597,6 +597,66 @@ enum pkcs11_ta_cmd {
 	 * processing matches.
 	 */
 	PKCS11_CMD_RELEASE_ACTIVE_PROCESSING = 44,
+
+	/*
+	 * PKCS11_CMD_DIGEST_INIT - Initialize a digest computation processing
+	 *
+	 * [in]  memref[0] = [
+	 *              32bit session handle,
+	 *              (struct pkcs11_attribute_head)mechanism + mecha params
+	 *	 ]
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 *
+	 * This command relates to the PKCS#11 API function C_DigestInit().
+	 */
+	PKCS11_CMD_DIGEST_INIT = 45,
+
+	/*
+	 * PKCS11_CMD_DIGEST_KEY - Update digest with a key
+	 *
+	 * [in]  memref[0] = [
+	 *              32bit session handle,
+	 *              32bit key handle
+	 *	 ]
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 *
+	 * This command relates to the PKCS#11 API function C_DigestKey().
+	 */
+	PKCS11_CMD_DIGEST_KEY = 46,
+
+	/*
+	 * PKCS11_CMD_DIGEST_UPDATE - Update digest with data
+	 *
+	 * [in]  memref[0] = 32bit session handle
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [in]  memref[1] = input data to be processed
+	 *
+	 * This command relates to the PKCS#11 API function C_DigestUpdate().
+	 */
+	PKCS11_CMD_DIGEST_UPDATE = 47,
+
+	/*
+	 * PKCS11_CMD_DIGEST_FINAL - Finalize a digest computation processing
+	 *
+	 * [in]  memref[0] = 32bit session handle
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = output digest
+	 *
+	 * This command relates to the PKCS#11 API function C_DigestFinal().
+	 */
+	PKCS11_CMD_DIGEST_FINAL = 48,
+
+	/*
+	 * PKCS11_CMD_DIGEST_ONESHOT - Compute a digest
+	 *
+	 * [in]  memref[0] = 32bit session handle
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [in]  memref[1] = input data to be processed
+	 * [out] memref[2] = byte array: generated digest
+	 *
+	 * This command relates to the PKCS#11 API function C_Digest().
+	 */
+	PKCS11_CMD_DIGEST_ONESHOT = 49,
 };
 
 /*
@@ -625,6 +685,7 @@ enum pkcs11_rc {
 	PKCS11_CKR_KEY_HANDLE_INVALID		= 0x0060,
 	PKCS11_CKR_KEY_SIZE_RANGE		= 0x0062,
 	PKCS11_CKR_KEY_TYPE_INCONSISTENT	= 0x0063,
+	PKCS11_CKR_KEY_INDIGESTIBLE		= 0x0067,
 	PKCS11_CKR_KEY_FUNCTION_NOT_PERMITTED	= 0x0068,
 	PKCS11_CKR_KEY_NOT_WRAPPABLE		= 0x0069,
 	PKCS11_CKR_KEY_UNEXTRACTABLE		= 0x006a,

--- a/libckteec/src/pkcs11_api.c
+++ b/libckteec/src/pkcs11_api.c
@@ -826,13 +826,20 @@ CK_RV C_DecryptFinal(CK_SESSION_HANDLE hSession,
 CK_RV C_DigestInit(CK_SESSION_HANDLE hSession,
 		   CK_MECHANISM_PTR pMechanism)
 {
-	(void)hSession;
-	(void)pMechanism;
+	CK_RV rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (!lib_initiated())
-		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (lib_initiated())
+		rv = ck_digest_init(hSession, pMechanism);
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	ASSERT_CK_RV(rv, CKR_ARGUMENTS_BAD, CKR_CRYPTOKI_NOT_INITIALIZED,
+		     CKR_DEVICE_ERROR, CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED,
+		     CKR_FUNCTION_CANCELED, CKR_FUNCTION_FAILED,
+		     CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_MECHANISM_INVALID,
+		     CKR_MECHANISM_PARAM_INVALID, CKR_OK, CKR_OPERATION_ACTIVE,
+		     CKR_PIN_EXPIRED, CKR_SESSION_CLOSED,
+		     CKR_SESSION_HANDLE_INVALID, CKR_USER_NOT_LOGGED_IN);
+
+	return rv;
 }
 
 CK_RV C_Digest(CK_SESSION_HANDLE hSession,
@@ -841,56 +848,80 @@ CK_RV C_Digest(CK_SESSION_HANDLE hSession,
 	       CK_BYTE_PTR pDigest,
 	       CK_ULONG_PTR pulDigestLen)
 {
-	(void)hSession;
-	(void)pData;
-	(void)ulDataLen;
-	(void)pDigest;
-	(void)pulDigestLen;
+	CK_RV rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (!lib_initiated())
-		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (lib_initiated())
+		rv = ck_digest_oneshot(hSession, pData, ulDataLen, pDigest,
+				       pulDigestLen);
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	ASSERT_CK_RV(rv, CKR_ARGUMENTS_BAD, CKR_BUFFER_TOO_SMALL,
+		     CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR,
+		     CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED,
+		     CKR_FUNCTION_CANCELED, CKR_FUNCTION_FAILED,
+		     CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK,
+		     CKR_OPERATION_NOT_INITIALIZED, CKR_SESSION_CLOSED,
+		     CKR_SESSION_HANDLE_INVALID);
+
+	return rv;
 }
 
 CK_RV C_DigestUpdate(CK_SESSION_HANDLE hSession,
 		     CK_BYTE_PTR pPart,
 		     CK_ULONG ulPartLen)
 {
-	(void)hSession;
-	(void)pPart;
-	(void)ulPartLen;
+	CK_RV rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (!lib_initiated())
-		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (lib_initiated())
+		rv = ck_digest_update(hSession, pPart, ulPartLen);
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	ASSERT_CK_RV(rv, CKR_ARGUMENTS_BAD, CKR_CRYPTOKI_NOT_INITIALIZED,
+		     CKR_DEVICE_ERROR, CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED,
+		     CKR_FUNCTION_CANCELED, CKR_FUNCTION_FAILED,
+		     CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK,
+		     CKR_OPERATION_NOT_INITIALIZED, CKR_SESSION_CLOSED,
+		     CKR_SESSION_HANDLE_INVALID);
+
+	return rv;
 }
 
 CK_RV C_DigestKey(CK_SESSION_HANDLE hSession,
 		  CK_OBJECT_HANDLE hKey)
 {
-	(void)hSession;
-	(void)hKey;
+	CK_RV rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (!lib_initiated())
-		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (lib_initiated())
+		rv = ck_digest_key(hSession, hKey);
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	ASSERT_CK_RV(rv, CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR,
+		     CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED,
+		     CKR_FUNCTION_CANCELED, CKR_FUNCTION_FAILED,
+		     CKR_GENERAL_ERROR, CKR_HOST_MEMORY,
+		     CKR_KEY_HANDLE_INVALID, CKR_KEY_INDIGESTIBLE,
+		     CKR_KEY_SIZE_RANGE, CKR_OK,
+		     CKR_OPERATION_NOT_INITIALIZED, CKR_SESSION_CLOSED,
+		     CKR_SESSION_HANDLE_INVALID);
+
+	return rv;
 }
 
 CK_RV C_DigestFinal(CK_SESSION_HANDLE hSession,
 		    CK_BYTE_PTR pDigest,
 		    CK_ULONG_PTR pulDigestLen)
 {
-	(void)hSession;
-	(void)pDigest;
-	(void)pulDigestLen;
+	CK_RV rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (!lib_initiated())
-		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (lib_initiated())
+		rv = ck_digest_final(hSession, pDigest, pulDigestLen);
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	ASSERT_CK_RV(rv, CKR_ARGUMENTS_BAD, CKR_BUFFER_TOO_SMALL,
+		     CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR,
+		     CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED,
+		     CKR_FUNCTION_CANCELED, CKR_FUNCTION_FAILED,
+		     CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK,
+		     CKR_OPERATION_NOT_INITIALIZED, CKR_SESSION_CLOSED,
+		     CKR_SESSION_HANDLE_INVALID);
+
+	return rv;
 }
 
 CK_RV C_SignInit(CK_SESSION_HANDLE hSession,

--- a/libckteec/src/pkcs11_processing.h
+++ b/libckteec/src/pkcs11_processing.h
@@ -7,6 +7,7 @@
 #define LIBCKTEEC_PKCS11_PROCESSING_H
 
 #include <pkcs11.h>
+#include <pkcs11_ta.h>
 
 CK_RV ck_create_object(CK_SESSION_HANDLE session, CK_ATTRIBUTE_PTR attribs,
 		       CK_ULONG count, CK_OBJECT_HANDLE_PTR phObject);
@@ -99,5 +100,8 @@ CK_RV ck_copy_object(CK_SESSION_HANDLE session,
 CK_RV ck_derive_key(CK_SESSION_HANDLE session, CK_MECHANISM_PTR mechanism,
 		    CK_OBJECT_HANDLE base_key, CK_ATTRIBUTE_PTR attribs,
 		    CK_ULONG count, CK_OBJECT_HANDLE_PTR handle);
+
+CK_RV ck_release_active_processing(CK_SESSION_HANDLE session,
+				   enum pkcs11_ta_cmd command);
 
 #endif /*LIBCKTEEC_PKCS11_PROCESSING_H*/

--- a/libckteec/src/pkcs11_processing.h
+++ b/libckteec/src/pkcs11_processing.h
@@ -38,6 +38,20 @@ CK_RV ck_encdecrypt_final(CK_SESSION_HANDLE session,
 			  CK_ULONG_PTR out_len,
 			  int decrypt);
 
+CK_RV ck_digest_init(CK_SESSION_HANDLE session, CK_MECHANISM_PTR mechanism);
+
+CK_RV ck_digest_key(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key);
+
+CK_RV ck_digest_update(CK_SESSION_HANDLE session, CK_BYTE_PTR in,
+		       CK_ULONG in_len);
+
+CK_RV ck_digest_oneshot(CK_SESSION_HANDLE session, CK_BYTE_PTR in,
+			CK_ULONG in_len, CK_BYTE_PTR out,
+			CK_ULONG_PTR out_len);
+
+CK_RV ck_digest_final(CK_SESSION_HANDLE session, CK_BYTE_PTR out,
+		      CK_ULONG_PTR out_len);
+
 CK_RV ck_signverify_init(CK_SESSION_HANDLE session,
 			 CK_MECHANISM_PTR mechanism,
 			 CK_OBJECT_HANDLE key,

--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -492,6 +492,12 @@ CK_RV serialize_ck_mecha_params(struct serializer *obj,
 	case CKM_AES_KEY_GEN:
 	case CKM_AES_ECB:
 	case CKM_AES_CMAC:
+	case CKM_MD5:
+	case CKM_SHA_1:
+	case CKM_SHA224:
+	case CKM_SHA256:
+	case CKM_SHA384:
+	case CKM_SHA512:
 	case CKM_MD5_HMAC:
 	case CKM_SHA_1_HMAC:
 	case CKM_SHA224_HMAC:


### PR DESCRIPTION
Implements support for digest operations as specified in:

PKCS #11 Cryptographic Token Interface Base Specification Version 2.40
Plus Errata 01
5.10 Message digesting functions

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>