### PR TITLE
libckteec: Add elliptic curve support

### DIFF
--- a/libckteec/include/pkcs11_ta.h
+++ b/libckteec/include/pkcs11_ta.h
@@ -657,6 +657,28 @@ enum pkcs11_ta_cmd {
 	 * This command relates to the PKCS#11 API function C_Digest().
 	 */
 	PKCS11_CMD_DIGEST_ONESHOT = 49,
+
+	/*
+	 * PKCS11_CMD_GENERATE_KEY_PAIR - Generate an asymmetric key pair
+	 *
+	 * [in]  memref[0] = [
+	 *              32bit session handle,
+	 *              (struct pkcs11_attribute_head)mechanism + mecha params,
+	 *              (struct pkcs11_object_head)public key attribs +
+	 *              attributes data,
+	 *              (struct pkcs11_object_head)private key attribs +
+	 *              attributes data
+	 *	 ]
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = [
+	 *              32bit public key object handle,
+	 *              32bit private key object handle
+	 *	 ]
+	 *
+	 * This command relates to the PKCS#11 API function
+	 * C_GenerateKeyPair().
+	 */
+	PKCS11_CMD_GENERATE_KEY_PAIR = 50,
 };
 
 /*

--- a/libckteec/src/pkcs11_api.c
+++ b/libckteec/src/pkcs11_api.c
@@ -1274,19 +1274,30 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE hSession,
 			CK_OBJECT_HANDLE_PTR phPublicKey,
 			CK_OBJECT_HANDLE_PTR phPrivateKey)
 {
-	(void)hSession;
-	(void)pMechanism;
-	(void)pPublicKeyTemplate;
-	(void)ulPublicKeyAttributeCount;
-	(void)pPrivateKeyTemplate;
-	(void)ulPrivateKeyAttributeCount;
-	(void)phPublicKey;
-	(void)phPrivateKey;
+	CK_RV rv = CKR_CRYPTOKI_NOT_INITIALIZED;
 
-	if (!lib_initiated())
-		return CKR_CRYPTOKI_NOT_INITIALIZED;
+	if (lib_initiated())
+		rv = ck_generate_key_pair(hSession, pMechanism,
+					  pPublicKeyTemplate,
+					  ulPublicKeyAttributeCount,
+					  pPrivateKeyTemplate,
+					  ulPrivateKeyAttributeCount,
+					  phPublicKey, phPrivateKey);
 
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	ASSERT_CK_RV(rv, CKR_ARGUMENTS_BAD, CKR_ATTRIBUTE_READ_ONLY,
+		     CKR_ATTRIBUTE_TYPE_INVALID, CKR_ATTRIBUTE_VALUE_INVALID,
+		     CKR_CRYPTOKI_NOT_INITIALIZED, CKR_CURVE_NOT_SUPPORTED,
+		     CKR_DEVICE_ERROR, CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED,
+		     CKR_DOMAIN_PARAMS_INVALID, CKR_FUNCTION_CANCELED,
+		     CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY,
+		     CKR_MECHANISM_INVALID, CKR_MECHANISM_PARAM_INVALID,
+		     CKR_OK, CKR_OPERATION_ACTIVE, CKR_PIN_EXPIRED,
+		     CKR_SESSION_CLOSED, CKR_SESSION_HANDLE_INVALID,
+		     CKR_SESSION_READ_ONLY, CKR_TEMPLATE_INCOMPLETE,
+		     CKR_TEMPLATE_INCONSISTENT, CKR_TOKEN_WRITE_PROTECTED,
+		     CKR_USER_NOT_LOGGED_IN);
+
+	return rv;
 }
 
 CK_RV C_WrapKey(CK_SESSION_HANDLE hSession,

--- a/libckteec/src/pkcs11_processing.h
+++ b/libckteec/src/pkcs11_processing.h
@@ -118,4 +118,13 @@ CK_RV ck_derive_key(CK_SESSION_HANDLE session, CK_MECHANISM_PTR mechanism,
 CK_RV ck_release_active_processing(CK_SESSION_HANDLE session,
 				   enum pkcs11_ta_cmd command);
 
+CK_RV ck_generate_key_pair(CK_SESSION_HANDLE session,
+			   CK_MECHANISM_PTR mechanism,
+			   CK_ATTRIBUTE_PTR pub_attribs,
+			   CK_ULONG pub_count,
+			   CK_ATTRIBUTE_PTR priv_attribs,
+			   CK_ULONG priv_count,
+			   CK_OBJECT_HANDLE_PTR pub_key,
+			   CK_OBJECT_HANDLE_PTR priv_key);
+
 #endif /*LIBCKTEEC_PKCS11_PROCESSING_H*/

--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -508,6 +508,7 @@ CK_RV serialize_ck_mecha_params(struct serializer *obj,
 	case CKM_SHA256_HMAC:
 	case CKM_SHA384_HMAC:
 	case CKM_SHA512_HMAC:
+	case CKM_EC_KEY_PAIR_GEN:
 		/* No parameter expected, size shall be 0 */
 		if (mechanism->ulParameterLen)
 			return CKR_MECHANISM_PARAM_INVALID;

--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -509,6 +509,12 @@ CK_RV serialize_ck_mecha_params(struct serializer *obj,
 	case CKM_SHA384_HMAC:
 	case CKM_SHA512_HMAC:
 	case CKM_EC_KEY_PAIR_GEN:
+	case CKM_ECDSA:
+	case CKM_ECDSA_SHA1:
+	case CKM_ECDSA_SHA224:
+	case CKM_ECDSA_SHA256:
+	case CKM_ECDSA_SHA384:
+	case CKM_ECDSA_SHA512:
 		/* No parameter expected, size shall be 0 */
 		if (mechanism->ulParameterLen)
 			return CKR_MECHANISM_PARAM_INVALID;


### PR DESCRIPTION
Add support for elliptic curve key pair generation, signing and verification operations.

Goes with:
- https://github.com/OP-TEE/optee_os/pull/4453
- https://github.com/OP-TEE/optee_test/pull/503

Relates to:
- https://github.com/OP-TEE/optee_os/issues/4283