### PR TITLE
libckteec: add missing unistd.h for group ID type

### DIFF
--- a/libckteec/src/invoke_ta.c
+++ b/libckteec/src/invoke_ta.c
@@ -18,6 +18,7 @@
 #include <sys/types.h>
 #include <tee_client_api.h>
 #include <teec_trace.h>
+#include <unistd.h>
 
 #include "ck_helpers.h"
 #include "invoke_ta.h"


### PR DESCRIPTION
libckteec: add missing unistd.h for group ID type

Include missing unistd.h to support type gid_t. This change fixes [1].

Link: [1] http://autobuild.buildroot.net/results/34b9946e6d59112a7eead304933534ad4739a84c/build-end.log
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
