### PR TITLE
libckteec: return CKR_CANT_LOCK if mutex fails at lib initialization

### DIFF
--- a/libckteec/src/invoke_ta.c
+++ b/libckteec/src/invoke_ta.c
@@ -283,11 +283,8 @@ CK_RV ckteec_invoke_init(void)
 	}
 
 	e = pthread_mutex_lock(&ta_ctx.init_mutex);
-	if (e) {
-		EMSG("pthread_mutex_lock: %s", strerror(e));
-		EMSG("terminating...");
-		exit(EXIT_FAILURE);
-	}
+	if (e)
+		return CKR_CANT_LOCK;
 
 	if (ta_ctx.initiated) {
 		rv = CKR_CRYPTOKI_ALREADY_INITIALIZED;


### PR DESCRIPTION
Return CKR_CANT_LOCK if mutex fails at lib initialization. This
conforms with the PKCS#11 specification v2.40-errata01. Preserve
the exit cases on mutex issues when unlocking and in C_Finalize().

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>