### PR TITLE
Allocate page aligned shared memory buffers

### DIFF
--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -128,6 +128,16 @@ static size_t num_waiters_dec(struct thread_arg *arg)
 	return ret;
 }
 
+static void *paged_aligned_alloc(size_t sz)
+{
+	void *p = NULL;
+
+	if (!posix_memalign(&p, sysconf(_SC_PAGESIZE), sz))
+		return p;
+
+	return NULL;
+}
+
 static int get_value(size_t num_params, struct tee_ioctl_param *params,
 		     const uint32_t idx, struct param_value **value)
 {
@@ -337,7 +347,7 @@ static struct tee_shm *register_local_shm(int fd, size_t size)
 
 	memset(&data, 0, sizeof(data));
 
-	buf = malloc(size);
+	buf = paged_aligned_alloc(size);
 	if (!buf)
 		return NULL;
 


### PR DESCRIPTION
Allocate page aligned shared memory buffer guarantee that each shared
memory buffer doesn't accidentally share a page of memory or they may
become aliased when mapped in secure world. This is normally not a big
problem but may make it a bit harder to track down buffer overruns in
shared memory buffers.

In a post Arm v8.4 architecture with FF-A [1] there's trouble since it's
not permitted to share the same physical page twice.

[1] https://developer.arm.com/documentation/den0077/latest
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Needed by https://github.com/OP-TEE/optee_os/pull/4509