### PR TITLE
Makefile: install optee_client_config.mk at INCLUDEDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ distclean: clean
 
 copy_export: build
 	mkdir -p $(DESTDIR)$(SBINDIR) $(DESTDIR)$(LIBDIR) $(DESTDIR)$(INCLUDEDIR)
-	cp config.mk $(DESTDIR)/optee_client_config.mk
+	cp config.mk $(DESTDIR)/$(INCLUDEDIR)/optee_client_config.mk
 	cp -a ${O}/libteec/libteec.so* $(DESTDIR)$(LIBDIR)
 	cp -a ${O}/libteec/libteec.a $(DESTDIR)$(LIBDIR)
 	cp ${O}/tee-supplicant/tee-supplicant $(DESTDIR)$(SBINDIR)


### PR DESCRIPTION
optee_client_config.mk should be installed to a more traditional and
common folder such as INCLUDEDIR instead of being installed directly to
DESTDIR (which can end up as / depending on the packaging system used).

This was noticed when packaging optee-client for OE, as DESTDIR gets set
to the deploy folder, which is later used as root for packaging
optee-client.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>