### PR TITLE
tee-supplicant: plugin: remove regular file type check

### DIFF
--- a/tee-supplicant/src/plugin.c
+++ b/tee-supplicant/src/plugin.c
@@ -122,48 +122,49 @@ TEEC_Result plugin_load_all(void)
 	}
 
 	while ((entry = readdir(dir))) {
-		if (entry->d_type == DT_REG) {
-			struct plugin *p;
+		struct plugin *p;
 
-			p = calloc(1, sizeof(struct plugin));
-			if (!p) {
-				EMSG("allocate mem for plugin <%s> failed",
-				     entry->d_name);
-				closedir(dir);
-				return TEEC_ERROR_OUT_OF_MEMORY;
-			}
+		if (!strcmp(entry->d_name, "..") || !strcmp(entry->d_name, "."))
+			continue;
 
-			res = load_plugin((const char *)entry->d_name, p);
-			switch (res) {
-			case PLUGIN_DL_OPEN_ERR:
-				EMSG("open plugin <%s> failed: %s",
-				     entry->d_name, dlerror());
-				free(p);
-				continue;
-			case PLUGIN_DL_SYM_ERR:
-				EMSG("find 'plugin_method' sym in <%s> failed: %s",
-				     entry->d_name, dlerror());
-				free(p);
-				continue;
-			default:
-				DMSG("loading the <%s> plugin were successful",
-				     p->method->name);
-				break;
-			}
-
-			/* Init the plugin */
-			if (p->method->init) {
-				teec_res = p->method->init();
-				if (teec_res) {
-					EMSG("init the <%s> plugin failed with 0x%x",
-					     p->method->name, teec_res);
-					free(p);
-					continue;
-				}
-			}
-
-			push_plugin(p);
+		p = calloc(1, sizeof(struct plugin));
+		if (!p) {
+			EMSG("allocate mem for plugin <%s> failed",
+			     entry->d_name);
+			closedir(dir);
+			return TEEC_ERROR_OUT_OF_MEMORY;
 		}
+
+		res = load_plugin((const char *)entry->d_name, p);
+		switch (res) {
+		case PLUGIN_DL_OPEN_ERR:
+			EMSG("open plugin <%s> failed: %s",
+			     entry->d_name, dlerror());
+			free(p);
+			continue;
+		case PLUGIN_DL_SYM_ERR:
+			EMSG("find 'plugin_method' sym in <%s> failed: %s",
+			     entry->d_name, dlerror());
+			free(p);
+			continue;
+		default:
+			DMSG("loading the <%s> plugin were successful",
+			     p->method->name);
+			break;
+		}
+
+		/* Init the plugin */
+		if (p->method->init) {
+			teec_res = p->method->init();
+			if (teec_res) {
+				EMSG("init the <%s> plugin failed with 0x%x",
+				     p->method->name, teec_res);
+				free(p);
+				continue;
+			}
+		}
+
+		push_plugin(p);
 	}
 
 	closedir(dir);


### PR DESCRIPTION
The readdir(3) man page mentions:
```
  Currently, only some filesystems (among them: Btrfs, ext2, ext3, and
  ext4) have full support for returning the file type in d_type. All
  applications must properly handle a return of DT_UNKNOWN.
```
Which is exactly the case on my nitrogen6x test system based on YOCTO
gatesgarth even using ext4:
```
  getdents64(4</usr/lib/tee-supplicant/plugins>,
  [{d_ino=3269, d_off=375390918, d_reclen=64, d_type=DT_UNKNOWN,
    d_name="f07bfc66-958c-4a15-99c0-260e4e7375dd.plugin"}, …], 32768) = 112
```
Even the regular test plugin for the tee-supplicant is identified as
DT_UNKNOWN, preventing the supplicant from loading the plugin.
Instead concatenate both the path and the filename and call stat(2) to
check if the resulting complete path is a regular file.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>