### PR TITLE
tee_supplicant.c: Fix shared memory size retrieval from OPTEE

### DIFF
--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -257,7 +257,7 @@ static int get_param(size_t num_params, struct tee_ioctl_param *params,
 		return -1;
 
 	shm->flags = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT;
-	shm->size = sz - offs;
+	shm->size = sz;
 	shm->id = MEMREF_SHM_ID(params + idx);
 	shm->buffer = (uint8_t *)tshm->p + offs;
 


### PR DESCRIPTION
The shared memory size got from tee_shm object already strips offset
from total buffer size.
The offset substraction breaks memref parameters through RPC when
applying offset to them.

Signed-off-by: Timothée Cercueil <timothee.cercueil@st.com>