### PR TITLE
libckteec: Fix signature size query for C_Sign/C_SignFinal

### DIFF
--- a/libckteec/src/pkcs11_processing.c
+++ b/libckteec/src/pkcs11_processing.c
@@ -736,7 +736,7 @@ CK_RV ck_signverify_oneshot(CK_SESSION_HANDLE session,
 	uint32_t session_handle = session;
 	size_t out_size = 0;
 
-	if ((in_len && !in) || (sign_len && *sign_len && !sign_ref) ||
+	if ((in_len && !in) || (!sign && sign_len && *sign_len && !sign_ref) ||
 	    (sign && !sign_len)) {
 		rv = CKR_ARGUMENTS_BAD;
 		goto bail;
@@ -764,7 +764,7 @@ CK_RV ck_signverify_oneshot(CK_SESSION_HANDLE session,
 	 * or
 	 * Shm io2: output signature (if signing) or null sized shm
 	 */
-	if (sign_len && *sign_len) {
+	if (sign_ref && sign_len && *sign_len) {
 		io2 = ckteec_register_shm(sign_ref, *sign_len,
 					  sign ? CKTEEC_SHM_OUT : CKTEEC_SHM_IN);
 	} else {
@@ -811,7 +811,8 @@ CK_RV ck_signverify_final(CK_SESSION_HANDLE session,
 	uint32_t session_handle = session;
 	size_t io_size = 0;
 
-	if ((sign_len && *sign_len && !sign_ref) || (sign && !sign_len)) {
+	if ((!sign && sign_len && *sign_len && !sign_ref) ||
+	    (sign && !sign_len)) {
 		rv = CKR_ARGUMENTS_BAD;
 		goto bail;
 	}
@@ -829,7 +830,7 @@ CK_RV ck_signverify_final(CK_SESSION_HANDLE session,
 	 * or
 	 * Shm io1: output signature (if signing) or null sized shm
 	 */
-	if (sign_len && *sign_len)
+	if (sign_ref && sign_len && *sign_len)
 		io = ckteec_register_shm(sign_ref, *sign_len,
 					 sign ? CKTEEC_SHM_OUT : CKTEEC_SHM_IN);
 	else


### PR DESCRIPTION
As specified in:
PKCS #11 Cryptographic Token Interface Base Specification
Version 2.40 Plus Errata 01
5.2 Conventions for functions returning output in a variable-length buffer

When querying size of returned variable-length buffer actual value of
*pulBufLen for input can be anything as long as pBuf is NULL and pulBufLen
is not NULL.

Related PRs:
- https://github.com/OP-TEE/optee_test/pull/524

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>