### PR TITLE
libckteec: Fix wrapped key output buffer size query for C_WrapKey

### DIFF
--- a/libckteec/src/pkcs11_processing.c
+++ b/libckteec/src/pkcs11_processing.c
@@ -1537,8 +1537,7 @@ CK_RV ck_wrap_key(CK_SESSION_HANDLE session, CK_MECHANISM_PTR mechanism,
 	size_t out_size = 0;
 	char *buf = NULL;
 
-	if (!mechanism || !wrapped_key_len ||
-	    (wrapped_key_len && *wrapped_key_len && !wrapped_key))
+	if (!mechanism || !wrapped_key_len)
 		return CKR_ARGUMENTS_BAD;
 
 	rv = serialize_ck_mecha_params(&smecha, mechanism);
@@ -1574,7 +1573,7 @@ CK_RV ck_wrap_key(CK_SESSION_HANDLE session, CK_MECHANISM_PTR mechanism,
 	memcpy(buf, smecha.buffer, smecha.size);
 
 	/* Shm io2: output buffer reference - wrapped key */
-	if (*wrapped_key_len)
+	if (wrapped_key && *wrapped_key_len)
 		out_shm = ckteec_register_shm(wrapped_key, *wrapped_key_len,
 					      CKTEEC_SHM_OUT);
 	else


### PR DESCRIPTION
As specified in:
PKCS #11 Cryptographic Token Interface Base Specification
Version 2.40 Plus Errata 01
5.2 Conventions for functions returning output in a variable-length buffer

When querying size of returned variable-length buffer actual value of
*pulBufLen for input can be anything as long as pBuf is NULL and pulBufLen
is not NULL.

Fixes problem found during reviewing PR:
https://github.com/OP-TEE/optee_os/pull/4469

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>