### PR TITLE
libckteec: In C_OpenSession() allow notify callback to be specified

### DIFF
--- a/libckteec/src/pkcs11_token.c
+++ b/libckteec/src/pkcs11_token.c
@@ -385,6 +385,10 @@ out:
 
 /**
  * ck_open_session - Wrap C_OpenSession into PKCS11_CMD_OPEN_{RW|RO}_SESSION
+ *
+ * Note: cookie and callback are not utilized by libckteec and are silently
+ * sinked in to have better out-of-box compatibility with 3rd party libraries
+ * and applications which provides the callback.
  */
 CK_RV ck_open_session(CK_SLOT_ID slot, CK_FLAGS flags, CK_VOID_PTR cookie,
 		      CK_NOTIFY callback, CK_SESSION_HANDLE_PTR session)
@@ -398,11 +402,12 @@ CK_RV ck_open_session(CK_SLOT_ID slot, CK_FLAGS flags, CK_VOID_PTR cookie,
 	size_t out_size = 0;
 	uint8_t *buf;
 
+	/* Ignore notify callback */
+	(void)cookie;
+	(void)callback;
+
 	if ((flags & ~(CKF_RW_SESSION | CKF_SERIAL_SESSION)) || !session)
 		return CKR_ARGUMENTS_BAD;
-
-	if (cookie || callback)
-		return CKR_FUNCTION_NOT_SUPPORTED;
 
 	/* Shm io0: (in/out) ctrl = [slot-id][flags] / [status] */
 	ctrl = ckteec_alloc_shm(sizeof(slot_id) + sizeof(u32_flags),


### PR DESCRIPTION
Some libraries registers notify callbacks to Cryptoki just to be on safe side
without having intention of aborting the operation.

Possibly uses for notify callback are defined in:

PKCS #11 Cryptographic Token Interface Base Specification
Version 2.40 Plus Errata 01
5.16 Callback functions

"A typical use of a surrender callback might be to give an application user
feedback during a lengthy key pair generation operation.  Each time the
application receives a callback, it could display an additional “.” to the user."

OP-TEE do not currently have this kind of mechanism to abort key generation
thus no need for such callback.

If callee has registered for such callback and is prepared to display progress
indication or abort the progress it will just never happen. User application
receives control back upon completion of such operaton.

It also states that:

"A Cryptoki library is not required to make any surrender callbacks."

So with the change we take liberty of not making the callbacks at all.

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>