### PR TITLE
libckteec: Add certificate object support

### DIFF
--- a/libckteec/include/pkcs11.h
+++ b/libckteec/include/pkcs11.h
@@ -242,6 +242,27 @@ typedef CK_KEY_TYPE *CK_KEY_TYPE_PTR;
 #define CKK_SHA224_HMAC			0x02e
 
 /*
+ * Certificates
+ */
+typedef CK_ULONG CK_CERTIFICATE_TYPE;
+typedef CK_ULONG CK_CERTIFICATE_CATEGORY;
+
+/*
+ * Valid values for attribute CKA_CERTIFICATE_TYPE
+ */
+#define CKC_X_509			0x00000000UL
+#define CKC_X_509_ATTR_CERT		0x00000001UL
+#define CKC_WTLS			0x00000002UL
+
+/*
+ * Valid values for attribute CKA_CERTIFICATE_CATEGORY
+ */
+#define CK_CERTIFICATE_CATEGORY_UNSPECIFIED	0UL
+#define CK_CERTIFICATE_CATEGORY_TOKEN_USER	1UL
+#define CK_CERTIFICATE_CATEGORY_AUTHORITY	2UL
+#define CK_CERTIFICATE_CATEGORY_OTHER_ENTITY	3UL
+
+/*
  * Mechanisms
  *
  * Note: a mechanism can be referenced as object reference in some PKCS#11 API

--- a/libckteec/include/pkcs11_ta.h
+++ b/libckteec/include/pkcs11_ta.h
@@ -1182,6 +1182,27 @@ enum pkcs11_key_type {
 };
 
 /*
+ * Valid values for attribute PKCS11_CKA_CERTIFICATE_TYPE
+ */
+enum pkcs11_certificate_type {
+	PKCS11_CKC_X_509		= 0x00000000UL,
+	PKCS11_CKC_X_509_ATTR_CERT	= 0x00000001UL,
+	PKCS11_CKC_WTLS			= 0x00000002UL,
+	/* Vendor extension: reserved for undefined ID (~0U) */
+	PKCS11_CKC_UNDEFINED_ID		= PKCS11_UNDEFINED_ID,
+};
+
+/*
+ * Valid values for attribute PKCS11_CKA_CERTIFICATE_CATEGORY
+ */
+enum pkcs11_certificate_category {
+	PKCS11_CK_CERTIFICATE_CATEGORY_UNSPECIFIED	= 0UL,
+	PKCS11_CK_CERTIFICATE_CATEGORY_TOKEN_USER	= 1UL,
+	PKCS11_CK_CERTIFICATE_CATEGORY_AUTHORITY	= 2UL,
+	PKCS11_CK_CERTIFICATE_CATEGORY_OTHER_ENTITY	= 3UL,
+};
+
+/*
  * Valid values for mechanism IDs
  * PKCS11_CKM_<x> reflects CryptoKi client API mechanism IDs CKM_<x>.
  */


### PR DESCRIPTION
Synchronize pkcs11 TA interface for certificate support.

Add necessary `pkcs11.h` definitions so that `xtest` can be compiled for pkcs11 certificate tests.

Relates to:
- https://github.com/OP-TEE/optee_os/issues/4283

Related PRs:
- https://github.com/OP-TEE/optee_os/pull/4797
- https://github.com/OP-TEE/optee_test/pull/542