### PR TITLE
libckteec: Add support for CKM_AES_CMAC_GENERAL

### DIFF
--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -659,6 +659,7 @@ CK_RV serialize_ck_mecha_params(struct serializer *obj,
 	case CKM_RSA_PKCS_OAEP:
 		return serialize_mecha_rsa_oaep_param(obj, &mecha);
 
+	case CKM_AES_CMAC_GENERAL:
 	case CKM_MD5_HMAC_GENERAL:
 	case CKM_SHA_1_HMAC_GENERAL:
 	case CKM_SHA224_HMAC_GENERAL:


### PR DESCRIPTION
Add support for CKM_AES_CMAC* mechanisms.

Signed-off-by: Victor Chong <victor.chong@linaro.org>