### PR TITLE
libckteec: Fix X.509 certificate attribute handlings

### DIFF
--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -195,7 +195,7 @@ static CK_RV serialize_ck_attribute(struct serializer *obj, CK_ATTRIBUTE *attr)
 			CK_ULONG ck_ulong = 0;
 
 			if (attr->ulValueLen < sizeof(CK_ULONG))
-				return CKR_ATTRIBUTE_TYPE_INVALID;
+				return CKR_ATTRIBUTE_VALUE_INVALID;
 
 			memcpy(&ck_ulong, attr->pValue, sizeof(ck_ulong));
 			pkcs11_data32 = ck_ulong;
@@ -297,7 +297,7 @@ static CK_RV deserialize_ck_attribute(struct pkcs11_attribute_head *in,
 	/* Specific ulong encoded as 32bit in PKCS11 TA API */
 	if (ck_attr_is_ulong(out->type)) {
 		if (out->ulValueLen < sizeof(CK_ULONG))
-			return CKR_ATTRIBUTE_TYPE_INVALID;
+			return CKR_ATTRIBUTE_VALUE_INVALID;
 
 		memcpy(&pkcs11_data32, data, sizeof(uint32_t));
 		if (out->type == CKA_KEY_GEN_MECHANISM &&

--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -136,6 +136,7 @@ static int ck_attr_is_ulong(CK_ATTRIBUTE_TYPE attribute_id)
 	switch (attribute_id) {
 	case CKA_CLASS:
 	case CKA_CERTIFICATE_TYPE:
+	case CKA_NAME_HASH_ALGORITHM:
 	case CKA_KEY_TYPE:
 	case CKA_HW_FEATURE_TYPE:
 	case CKA_MECHANISM_TYPE:

--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -136,6 +136,7 @@ static int ck_attr_is_ulong(CK_ATTRIBUTE_TYPE attribute_id)
 	switch (attribute_id) {
 	case CKA_CLASS:
 	case CKA_CERTIFICATE_TYPE:
+	case CKA_CERTIFICATE_CATEGORY:
 	case CKA_NAME_HASH_ALGORITHM:
 	case CKA_KEY_TYPE:
 	case CKA_HW_FEATURE_TYPE:


### PR DESCRIPTION
CK_ULONG conversion was forgotten on first batch so this adds them.

Also fixes error value returned when provided CK_ULONG value is too small.

Relates to:
- https://github.com/OP-TEE/optee_os/issues/4283

Related PRs:
- https://github.com/OP-TEE/optee_os/pull/4797
- https://github.com/OP-TEE/optee_test/pull/542