### PR TITLE
libteec: copy out partial shadow buffer

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -48,6 +48,8 @@
 
 #include "teec_benchmark.h"
 
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
 /* How many device sequence numbers will be tried before giving up */
 #define TEEC_MAX_DEV_SEQ	10
 
@@ -398,10 +400,9 @@ static void teec_post_process_tmpref(uint32_t param_type,
 			TEEC_SharedMemory *shm)
 {
 	if (param_type != TEEC_MEMREF_TEMP_INPUT) {
-		if (MEMREF_SIZE(param) <= tmpref->size && tmpref->buffer &&
-		    shm->shadow_buffer)
+		if (tmpref->buffer && shm->shadow_buffer)
 			memcpy(tmpref->buffer, shm->shadow_buffer,
-			       MEMREF_SIZE(param));
+			       MIN(MEMREF_SIZE(param), tmpref->size));
 
 		tmpref->size = MEMREF_SIZE(param);
 	}


### PR DESCRIPTION
Without dynamic shared memory enabled (CFG_CORE_DYN_SHM=n) temporary
memrefs uses a shadow buffer to transport data to and from the kernel.

Prior to this patch in case the out length of such a buffer is larger
than the initial size then no copy out is performed even though some
relevant data may be available. Fix this by copying out as much data as
the shadow buffer can hold.

Fixes: https://github.com/OP-TEE/optee_os/issues/5101
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>