### PR TITLE
libckteec: add support for ECDH derive

### DIFF
--- a/libckteec/include/pkcs11.h
+++ b/libckteec/include/pkcs11.h
@@ -438,6 +438,27 @@ typedef CK_ULONG CK_RSA_PKCS_OAEP_SOURCE_TYPE;
 typedef CK_ULONG CK_MAC_GENERAL_PARAMS;
 typedef CK_MAC_GENERAL_PARAMS *CK_MAC_GENERAL_PARAMS_PTR;
 
+/*
+ * CK_EC_KDF_TYPE is used to indicate the Key Derivation Function (KDF) applied
+ * to derive keying data from a shared secret.
+ */
+typedef CK_ULONG CK_EC_KDF_TYPE;
+
+/*
+ * Elliptic curve Diffie-Hellman key derivation
+ * Elliptic curve Diffie-Hellman cofactor key derivation parameters
+ */
+typedef struct CK_ECDH1_DERIVE_PARAMS CK_ECDH1_DERIVE_PARAMS;
+typedef struct CK_ECDH1_DERIVE_PARAMS *CK_ECDH1_DERIVE_PARAMS_PTR;
+
+struct CK_ECDH1_DERIVE_PARAMS {
+	CK_EC_KDF_TYPE		kdf;
+	CK_ULONG		ulSharedDataLen;
+	CK_BYTE_PTR		pSharedData;
+	CK_ULONG		ulPublicDataLen;
+	CK_BYTE_PTR		pPublicData;
+};
+
 /* AES CBC encryption parameters */
 typedef struct CK_AES_CBC_ENCRYPT_DATA_PARAMS CK_AES_CBC_ENCRYPT_DATA_PARAMS;
 typedef struct CK_AES_CBC_ENCRYPT_DATA_PARAMS

--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -451,6 +451,43 @@ static CK_RV serialize_mecha_key_deriv_str(struct serializer *obj,
 	return serialize_buffer(obj, param->pData, param->ulLen);
 }
 
+static CK_RV serialize_mecha_ecdh1_derive_param(struct serializer *obj,
+						CK_MECHANISM_PTR mecha)
+{
+	CK_ECDH1_DERIVE_PARAMS *params = mecha->pParameter;
+	CK_RV rv = CKR_GENERAL_ERROR;
+	size_t params_size = 3 * sizeof(uint32_t) + params->ulSharedDataLen +
+			     params->ulPublicDataLen;
+
+	rv = serialize_32b(obj, obj->type);
+	if (rv)
+		return rv;
+
+	rv = serialize_32b(obj, params_size);
+	if (rv)
+		return rv;
+
+	rv = serialize_32b(obj, params->kdf);
+	if (rv)
+		return rv;
+
+	rv = serialize_32b(obj, params->ulSharedDataLen);
+	if (rv)
+		return rv;
+
+	rv = serialize_buffer(obj, params->pSharedData,
+			      params->ulSharedDataLen);
+	if (rv)
+		return rv;
+
+	rv = serialize_32b(obj, params->ulPublicDataLen);
+	if (rv)
+		return rv;
+
+	return serialize_buffer(obj, params->pPublicData,
+				params->ulPublicDataLen);
+}
+
 static CK_RV serialize_mecha_aes_cbc_encrypt_data(struct serializer *obj,
 						  CK_MECHANISM_PTR mecha)
 {
@@ -649,6 +686,10 @@ CK_RV serialize_ck_mecha_params(struct serializer *obj,
 
 	case CKM_AES_CBC_ENCRYPT_DATA:
 		return serialize_mecha_aes_cbc_encrypt_data(obj, &mecha);
+
+	case CKM_ECDH1_DERIVE:
+	case CKM_ECDH1_COFACTOR_DERIVE:
+		return serialize_mecha_ecdh1_derive_param(obj, &mecha);
 
 	case CKM_RSA_PKCS_PSS:
 	case CKM_SHA1_RSA_PKCS_PSS:


### PR DESCRIPTION
This commit integrates previous work done by Etienne Carriere and Vesa
Jääskeläinen.

Tested with pkcs11_tool -m ECDH1-DERIVE

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

ref: https://github.com/OP-TEE/optee_os/pull/5130