### PR TITLE
More env support

### DIFF
--- a/tee-supplicant/src/plugin.c
+++ b/tee-supplicant/src/plugin.c
@@ -113,9 +113,10 @@ TEEC_Result plugin_load_all(void)
 	TEEC_Result teec_res = TEEC_SUCCESS;
 	struct dirent *entry = NULL;
 
-	dir = opendir(TEE_PLUGIN_LOAD_PATH);
+	dir = opendir(supplicant_params.plugin_load_path);
+
 	if (!dir) {
-		IMSG("could not open directory %s", TEE_PLUGIN_LOAD_PATH);
+		IMSG("could not open directory %s", supplicant_params.plugin_load_path);
 
 		/* don't generate error if there is no the dir */
 		return TEEC_SUCCESS;

--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -121,7 +121,8 @@ static int tee_supp_fs_init(void)
 	size_t n = 0;
 	mode_t mode = 0700;
 
-	n = snprintf(tee_fs_root, sizeof(tee_fs_root), "%s/", TEE_FS_PARENT_PATH);
+	n = snprintf(tee_fs_root, sizeof(tee_fs_root), "%s/", supplicant_params.fs_parent_path);
+
 	if (n >= sizeof(tee_fs_root))
 		return -1;
 
@@ -613,7 +614,7 @@ TEEC_Result tee_supp_fs_process(size_t num_params,
 	if (strlen(tee_fs_root) == 0) {
 		if (tee_supp_fs_init() != 0) {
 			EMSG("error tee_supp_fs_init: failed to create %s/",
-				TEE_FS_PARENT_PATH);
+				tee_fs_root);
 			memset(tee_fs_root, 0, sizeof(tee_fs_root));
 			return TEEC_ERROR_STORAGE_NOT_AVAILABLE;
 		}

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -31,6 +31,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <getopt.h>
 #include <inttypes.h>
 #include <prof.h>
 #include <plugin.h>
@@ -484,9 +485,16 @@ static int get_dev_fd(uint32_t *gen_caps)
 
 static int usage(int status)
 {
-	fprintf(stderr, "Usage: tee-supplicant [-d] [<device-name>]\n");
-	fprintf(stderr, "       -d: run as a daemon (fork after successful "
+	fprintf(stderr, "Usage: tee-supplicant [options] [<device-name>]\n");
+	fprintf(stderr, "\t-h, --help: this help\n");
+	fprintf(stderr, "\t-d, --daemonize: run as a daemon (fork after successful "
 			"initialization)\n");
+	fprintf(stderr, "\t-f, --fs-parent-path: secure fs parent path [%s]\n",
+			supplicant_params.fs_parent_path);
+	fprintf(stderr, "\t-t, --ta-dir: TAs dirname under %s [%s]\n", TEEC_LOAD_PATH,
+			supplicant_params.ta_dir);
+	fprintf(stderr, "\t-p, --plugin-path: plugin load path [%s]\n",
+			supplicant_params.plugin_load_path);
 	return status;
 }
 
@@ -688,7 +696,8 @@ int main(int argc, char *argv[])
 	bool daemonize = false;
 	char *dev = NULL;
 	int e = 0;
-	int i = 0;
+	int long_index = 0;
+	int opt = 0;
 
 	e = pthread_mutex_init(&arg.mutex, NULL);
 	if (e) {
@@ -697,16 +706,48 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 
-	if (argc > 3)
-		return usage(EXIT_FAILURE);
+	static struct option long_options[] = {
+		/* long name      | has argument  | flag | short value */
+		{ "help",            no_argument,       0, 'h' },
+		{ "daemonize",       no_argument,       0, 'd' },
+		{ "fs-parent-path",  required_argument, 0, 'f' },
+		{ "ta-dir",          required_argument, 0, 't' },
+		{ "plugin-path",     required_argument, 0, 'p' },
+		{ 0, 0, 0, 0 }
+	};
 
-	for (i = 1; i < argc; i++) {
-		if (!strcmp(argv[i], "-d"))
-			daemonize = true;
-		else if (!strcmp(argv[i], "-h"))
-			return usage(EXIT_SUCCESS);
-		else
-			dev = argv[i];
+	while ((opt = getopt_long(argc, argv, "hdf:t:p:",
+				long_options, &long_index )) != -1) {
+		switch (opt) {
+			case 'h' :
+				return usage(EXIT_SUCCESS);
+				break;
+			case 'd':
+				daemonize = true;
+				break;
+			case 'f':
+				supplicant_params.fs_parent_path = optarg;
+				break;
+			case 't':
+				supplicant_params.ta_dir = optarg;
+				break;
+			case 'p':
+				supplicant_params.plugin_load_path = optarg;
+				break;
+			default:
+				return usage(EXIT_FAILURE);
+		}
+	}
+	/* check for non option argument, which is device name */
+	if (argv[optind]) {
+		fprintf(stderr, "Using device %s.\n", argv[optind]);
+		dev = argv[optind];
+		/* check that we do not have too many arguments */
+		if (argv[optind + 1]) {
+			fprintf(stderr, "Too many arguments passed: extra argument: %s.\n",
+					argv[optind+1]);
+			return usage(EXIT_FAILURE);
+		}
 	}
 
 	if (daemonize && daemon(0, 0) < 0) {

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -98,7 +98,11 @@ struct param_value {
 static pthread_mutex_t shm_mutex = PTHREAD_MUTEX_INITIALIZER;
 static struct tee_shm *shm_head;
 
-static const char *ta_dir;
+struct tee_supplicant_params supplicant_params = {
+	.ta_dir = "optee_armtz",
+	.plugin_load_path = TEE_PLUGIN_LOAD_PATH,
+	.fs_parent_path  = TEE_FS_PARENT_PATH,
+};
 
 static void *thread_main(void *a);
 
@@ -290,7 +294,7 @@ static uint32_t load_ta(size_t num_params, struct tee_ioctl_param *params)
 	uuid_from_octets(&uuid, (void *)val_cmd);
 
 	size = shm_ta.size;
-	ta_found = TEECI_LoadSecureModule(ta_dir, &uuid, shm_ta.buffer, &size);
+	ta_found = TEECI_LoadSecureModule(supplicant_params.ta_dir, &uuid, shm_ta.buffer, &size);
 	if (ta_found != TA_BINARY_FOUND) {
 		EMSG("  TA not found");
 		return TEEC_ERROR_ITEM_NOT_FOUND;
@@ -453,7 +457,6 @@ static int open_dev(const char *devname, uint32_t *gen_caps)
 	if (vers.impl_id != TEE_IMPL_ID_OPTEE)
 		goto err;
 
-	ta_dir = "optee_armtz";
 	if (gen_caps)
 		*gen_caps = vers.gen_caps;
 

--- a/tee-supplicant/src/tee_supplicant.h
+++ b/tee-supplicant/src/tee_supplicant.h
@@ -38,6 +38,15 @@
 
 struct tee_ioctl_param;
 
+/* Global tee-supplicant parameters */
+struct tee_supplicant_params {
+    const char *ta_dir;
+    const char *plugin_load_path;
+    const char *fs_parent_path;
+};
+
+extern struct tee_supplicant_params supplicant_params;
+
 bool tee_supp_param_is_memref(struct tee_ioctl_param *param);
 bool tee_supp_param_is_value(struct tee_ioctl_param *param);
 void *tee_supp_param_to_va(struct tee_ioctl_param *param);


### PR DESCRIPTION
Add support to define tee supplicant paths at the run time using env variables.
`OP_TEE_FS_PARENT_PATH`, `OP_TEE_LIB`, and `OP_TEE_PLUGIN_LOAD_PATH`

When trying to run tee supplicant process in confinement, some critical directories needs to be defined dynamically during runtime, rather than at the build time.
This PR enables this run time scenario.