### PR TITLE
tee-supplicant: add --rpmb-cid command line option

### DIFF
--- a/tee-supplicant/src/rpmb.c
+++ b/tee-supplicant/src/rpmb.c
@@ -64,9 +64,11 @@ struct rpmb_req {
 };
 #define RPMB_REQ_DATA(req) ((void *)((struct rpmb_req *)(req) + 1))
 
+#define RPMB_CID_SZ 16
+
 /* Response to device info request */
 struct rpmb_dev_info {
-	uint8_t cid[16];
+	uint8_t cid[RPMB_CID_SZ];
 	uint8_t rpmb_size_mult;	/* EXT CSD-slice 168: RPMB Size */
 	uint8_t rel_wr_sec_c;	/* EXT CSD-slice 222: Reliable Write Sector */
 				/*                    Count */
@@ -230,39 +232,77 @@ static ssize_t readn(int fd, void *ptr, size_t n)
 	return n - nleft; /* return >= 0 */
 }
 
-/* Device Identification (CID) register is 16 bytes. It is read from sysfs. */
-static uint32_t read_cid(uint16_t dev_id, uint8_t *cid)
+/* Size of CID printed in hexadecimal */
+#define CID_STR_SZ (2 * RPMB_CID_SZ)
+
+static TEEC_Result read_cid_str(uint16_t dev_id, char cid[CID_STR_SZ + 1])
 {
 	TEEC_Result res = TEEC_ERROR_GENERIC;
 	char path[48] = { 0 };
-	char hex[3] = { 0 };
-	int st = 0;
 	int fd = 0;
-	int i = 0;
+	int st = 0;
 
 	snprintf(path, sizeof(path),
 		 "/sys/class/mmc_host/mmc%u/mmc%u:0001/cid", dev_id, dev_id);
 	fd = open(path, O_RDONLY);
-	if (fd < 0) {
-		EMSG("Could not open %s (%s)", path, strerror(errno));
+	if (fd < 0)
 		return TEEC_ERROR_ITEM_NOT_FOUND;
-	}
-
-	for (i = 0; i < 16; i++) {
-		st = readn(fd, hex, 2);
-		if (st != 2) {
-			EMSG("Read CID error");
-			if (errno)
-				EMSG("%s", strerror(errno));
-			res = TEEC_ERROR_NO_DATA;
-			goto err;
-		}
-		cid[i] = (uint8_t)strtol(hex, NULL, 16);
+	st = readn(fd, cid, CID_STR_SZ);
+	if (st != CID_STR_SZ) {
+		EMSG("Read CID error");
+		if (errno)
+			EMSG("%s", strerror(errno));
+		res = TEEC_ERROR_NO_DATA;
+		goto out;
 	}
 	res = TEEC_SUCCESS;
-err:
+out:
 	close(fd);
 	return res;
+}
+
+static int hexchar2int(char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	if (c >= 'a' && c <= 'f')
+		return c - 'a' + 10;
+	if (c >= 'A' && c <= 'F')
+		return c - 'A' + 10;
+	return -1;
+}
+
+static int hexbyte2int(char *hex)
+{
+	int v1 = hexchar2int(hex[0]);
+	int v2 = hexchar2int(hex[1]);
+
+	if (v1 < 0 || v2 < 0)
+		return -1;
+	return 16 * v1 + v2;
+}
+
+/* Device Identification (CID) register is 16 bytes. It is read from sysfs. */
+static TEEC_Result read_cid(uint16_t dev_id, uint8_t *cid)
+{
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	char cid_str[CID_STR_SZ + 1] = { };
+	int i = 0;
+	int v = 0;
+
+	res = read_cid_str(dev_id, cid_str);
+	if (res)
+		return res;
+
+	for (i = 0; i < RPMB_CID_SZ; i++) {
+		v = hexbyte2int(cid_str + 2 * i);
+		if (v < 0) {
+			EMSG("Invalid CID string: %s", cid_str);
+			return TEEC_ERROR_NO_DATA;
+		}
+		cid[i] = v;
+	}
+	return TEEC_SUCCESS;
 }
 
 #else /* RPMB_EMU */

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -495,6 +495,8 @@ static int usage(int status)
 			supplicant_params.ta_dir);
 	fprintf(stderr, "\t-p, --plugin-path: plugin load path [%s]\n",
 			supplicant_params.plugin_load_path);
+	fprintf(stderr, "\t-r, --rpmb-cid: RPMB device identification register "
+			"(CID) in hexadecimal\n");
 	return status;
 }
 
@@ -713,6 +715,7 @@ int main(int argc, char *argv[])
 		{ "fs-parent-path",  required_argument, 0, 'f' },
 		{ "ta-dir",          required_argument, 0, 't' },
 		{ "plugin-path",     required_argument, 0, 'p' },
+		{ "rpmb-cid",        required_argument, 0, 'r' },
 		{ 0, 0, 0, 0 }
 	};
 
@@ -733,6 +736,9 @@ int main(int argc, char *argv[])
 				break;
 			case 'p':
 				supplicant_params.plugin_load_path = optarg;
+				break;
+			case 'r':
+				supplicant_params.rpmb_cid = optarg;
 				break;
 			default:
 				return usage(EXIT_FAILURE);

--- a/tee-supplicant/src/tee_supplicant.h
+++ b/tee-supplicant/src/tee_supplicant.h
@@ -43,6 +43,7 @@ struct tee_supplicant_params {
     const char *ta_dir;
     const char *plugin_load_path;
     const char *fs_parent_path;
+    const char *rpmb_cid;
 };
 
 extern struct tee_supplicant_params supplicant_params;


### PR DESCRIPTION
In OP-TEE OS, the RPMB device used for secure storage is selected at
compile time via an integer identifier (CFG_RPMB_FS_DEV_ID). As
mentioned in [1], this ID is assigned by the Linux kernel and is used
when tee-supplicant opens the device on behalf of OP-TEE. There are a
couple of issues with that:

1. U-Boot and Linux may assign a different number to the same RPMB
device. Therefore, the TEE supplicant components in U-Boot and Linux
cannot both trust the ID given by OP-TEE.

2. If a system has several RPMB devices, and even if we ignore removable
ones, there is no guarantee that the devices will always be enumerated
in the same order by the kernel on boot. This results in different
device numbers. I observed this behavior on a Hikey620 board with an
external eMMC module plugged into the micro SD slot. Sometimes the
on-board RPMB (which I don’t use for testing) is /dev/mmcblk0rpmb and
the external one is /dev/mmcblk1rpmb; sometimes it is the other way
around.

In order to remove any ambiguity, introduce a new command line argument
to tee-supplicant: --rpmb-cid <CID>. <CID> is the device identification
register of the eMMC device that OP-TEE should use for RPMB. It is
unique for every flash device. When --rpmb-cid is given, the device
number given by OP-TEE is ignored and the specified device is used
instead. <CID> can be found in sysfs, for example:
```
 # Read the CID of MMC device 0. Its RPMB partition is /dev/mmcblk0rpmb.
 $ cat /sys/class/mmc_host/mmc0/mmc0\:0001/cid
 11010030303847453000e0a18ceb13df
 $
```
Link: https://github.com/OP-TEE/optee_os/blob/3.16.0/mk/config.mk#L159-L162
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>