### PR TITLE
tee-supplicant: accept -r as a short option for --rpmb-cid

### DIFF
--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -719,7 +719,7 @@ int main(int argc, char *argv[])
 		{ 0, 0, 0, 0 }
 	};
 
-	while ((opt = getopt_long(argc, argv, "hdf:t:p:",
+	while ((opt = getopt_long(argc, argv, "hdf:t:p:r:",
 				long_options, &long_index )) != -1) {
 		switch (opt) {
 			case 'h' :


### PR DESCRIPTION
Commit 5a69d55d6596 ("tee-supplicant: add --rpmb-cid command line option")
mentions in the help string that -r is synonymous for --rpmb-cid, but
it's not. Add the missing characters to the getopt_long() optstring
argument.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>