### PR TITLE
tee-supplicant: close shm fd before freeing memory

### DIFF
--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -420,19 +420,18 @@ static uint32_t process_free(size_t num_params, struct tee_ioctl_param *params)
 	if (!shm)
 		return TEEC_ERROR_BAD_PARAMETERS;
 
+	close(shm->fd);
 	if (shm->registered) {
 		free(shm->p);
 	} else  {
 		if (munmap(shm->p, shm->size) != 0) {
 			EMSG("munmap(%p, %zu) failed - Error = %s",
 			     shm->p, shm->size, strerror(errno));
-			close(shm->fd);
 			free(shm);
 			return TEEC_ERROR_BAD_PARAMETERS;
 		}
 	}
 
-	close(shm->fd);
 	free(shm);
 	return TEEC_SUCCESS;
 }


### PR DESCRIPTION
The resources of a shm is released in process_free(), this includes the
file descriptor and the memory buffer which was registered. Closing
the file descriptor unregisters the memory buffer.

The memory buffer was, prior to this patch, freed before the file
descriptor was closed. This could lead to another thread reusing this
memory buffer before it has been unregistered. This is normally not a
problem since the buffer will not be read or modified after it has been
freed. However, FF-A mandates that a physical memory isn't registered
already when registering. Son in the case we can have occasional failures.

Fixes: 075c56eebdc9 ("tee_supplicant: add register memory feature")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>