### PR TITLE
tee-supplicant: support multiple TA load paths

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -30,7 +30,10 @@ CFG_TEE_FS_PARENT_PATH ?= /data/tee
 CFG_TEE_CLIENT_LOG_FILE ?= $(CFG_TEE_FS_PARENT_PATH)/teec.log
 
 # CFG_TEE_CLIENT_LOAD_PATH
-#   The location of the client library file.
+#   Colon-separated list of paths where tee-supplicant loads TAs from.
+#   For example: CFG_TEE_CLIENT_LOAD_PATH ?= /lib:/vendor/lib
+#   Note that the TA files are typically in a sub-directory (see the
+#   --ta-dir option).
 CFG_TEE_CLIENT_LOAD_PATH ?= /lib
 
 # CFG_TEE_SUPP_PLUGINS

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -11,7 +11,7 @@ option (CFG_TEE_SUPP_PLUGINS "Enable tee-supplicant plugin support" ON)
 
 set (CFG_TEE_SUPP_LOG_LEVEL "1" CACHE STRING "tee-supplicant log level")
 # FIXME: Question is, is this really needed? Should just use defaults from # GNUInstallDirs?
-set (CFG_TEE_CLIENT_LOAD_PATH "/lib" CACHE STRING "Location of libteec.so")
+set (CFG_TEE_CLIENT_LOAD_PATH "/lib" CACHE STRING "Colon-separated list of paths where to look for TAs (see also --ta-dir)")
 set (CFG_TEE_FS_PARENT_PATH "/data/tee" CACHE STRING "Location of TEE filesystem (secure storage)")
 # FIXME: Why do we have if defined(CFG_GP_SOCKETS) && CFG_GP_SOCKETS == 1 in the c-file?
 set (CFG_GP_SOCKETS "1" CACHE STRING "Enable GlobalPlatform Socket API support")

--- a/tee-supplicant/src/teec_ta_load.c
+++ b/tee-supplicant/src/teec_ta_load.c
@@ -67,6 +67,9 @@ struct tee_rpc_cmd {
  * Based on the uuid this function will try to find a TA-binary on the
  * filesystem and return it back to the caller in the parameter ta.
  *
+ * @param: prefix       Prefix for TA load path
+ * @param: dev_path     Where to load the TA from. The full path to the TA
+ *                      binary is @prefix/@dev_path/@destination.ta.
  * @param: destination  The uuid of the TA we are searching for.
  * @param: ta           A pointer which this function will allocate and copy
  *                      the TA from the filesystem to the pointer itself. It is
@@ -176,15 +179,14 @@ int TEECI_LoadSecureModule(const char* dev_path,
 			   const TEEC_UUID *destination, void *ta,
 			   size_t *ta_size)
 {
-#ifdef TEEC_TEST_LOAD_PATH
-	int res = 0;
+	int res = TA_BINARY_NOT_FOUND;
+	char **path = NULL;
 
-	res = try_load_secure_module(TEEC_TEST_LOAD_PATH,
-				     dev_path, destination, ta, ta_size);
-	if (res != TA_BINARY_NOT_FOUND)
-		return res;
-#endif
-
-	return try_load_secure_module(TEEC_LOAD_PATH,
-				      dev_path, destination, ta, ta_size);
+	for (path = ta_path; *path; path++) {
+		res = try_load_secure_module(*path, dev_path, destination, ta,
+					     ta_size);
+		if (res == TA_BINARY_FOUND)
+			break;
+	}
+	return res;
 }

--- a/tee-supplicant/src/teec_ta_load.h
+++ b/tee-supplicant/src/teec_ta_load.h
@@ -31,6 +31,11 @@
 #define TA_BINARY_FOUND 0
 #define TA_BINARY_NOT_FOUND -1
 
+/* Heap copy of TA load paths, separated by '\0' (access via ta_path) */
+extern char *ta_path_str;
+/* NULL-terminated list of paths (pointers into ta_path_str) */
+extern char **ta_path;
+
 /**
  * Based on the uuid this function will try to find a TA-binary on the
  * filesystem and return it back to the caller in the parameter ta.


### PR DESCRIPTION
Parse CFG_TEE_CLIENT_LOAD_PATH (TEEC_LOAD_PATH) and TEEC_TEST_LOAD_PATH
as a colon-separated list of paths. This commit also updates the
documentation of CFG_TEE_CLIENT_LOAD_PATH and try_load_secure_module()
which were either lacking or incorrect.

Suggested-by: Chao Chen <ccha@amazon.com>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>