### PR TITLE
cmake: fix log level don't take effect

### DIFF
--- a/libteec/CMakeLists.txt
+++ b/libteec/CMakeLists.txt
@@ -45,7 +45,7 @@ set_target_properties (teec PROPERTIES
 ################################################################################
 target_compile_definitions (teec
 	PRIVATE -D_GNU_SOURCE
-	PRIVATE -DCFG_TEE_CLIENT_LOG_LEVEL=${CFG_TEE_CLIENT_LOG_LEVEL}
+	PRIVATE -DDEBUGLEVEL_${CFG_TEE_CLIENT_LOG_LEVEL}
 	PRIVATE -DTEEC_LOG_FILE="${CFG_TEE_CLIENT_LOG_FILE}"
 	PRIVATE -DBINARY_PREFIX="LT"
 )

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -55,7 +55,7 @@ add_executable (${PROJECT_NAME} ${SRC})
 # Flags always set
 ################################################################################
 target_compile_definitions (${PROJECT_NAME}
-	PRIVATE -DCFG_TEE_SUPP_LOG_LEVEL=${CFG_TEE_SUPP_LOG_LEVEL}
+	PRIVATE -DDEBUGLEVEL_${CFG_TEE_SUPP_LOG_LEVEL}
 	PRIVATE -DTEEC_LOAD_PATH="${CFG_TEE_CLIENT_LOAD_PATH}"
 	PRIVATE -DTEE_FS_PARENT_PATH="${CFG_TEE_FS_PARENT_PATH}"
 	PRIVATE -DBINARY_PREFIX="TSUP"


### PR DESCRIPTION
CFG_TEE_CLIENT_LOG_LEVEL and CFG_TEE_SUPP_LOG_LEVEL have no effect on
DEBUGLEVEL_X when compiling with cmake.

Therefore, modifying the values of CFG_TEE_CLIENT_LOG_LEVEL and
CFG_TEE_SUPP_LOG_LEVEL cannot set the log level.

Signed-off-by: Lejia Zhang zhanlej@gmail.com