### PR TITLE
tee-supplicant: android: make RPMB_EMU a conditional assignment

### DIFF
--- a/tee-supplicant/tee_supplicant_android.mk
+++ b/tee-supplicant/tee_supplicant_android.mk
@@ -30,7 +30,7 @@ LOCAL_SRC_FILES += src/tee_socket.c
 LOCAL_CFLAGS += -DCFG_GP_SOCKETS=1
 endif
 
-RPMB_EMU        := 1
+RPMB_EMU ?= 1
 ifeq ($(RPMB_EMU),1)
 LOCAL_SRC_FILES += src/sha2.c src/hmac_sha2.c
 LOCAL_CFLAGS += -DRPMB_EMU=1


### PR DESCRIPTION
At the moment the RPMB_EMU variable in the Makefile uses a simple assignment and unconditionally sets the variable.

Move it to a conditional assignment and allow users to override it.