### PR TITLE
libteec: fix memory mapping function in benchmark

### DIFF
--- a/libteec/src/teec_benchmark.c
+++ b/libteec/src/teec_benchmark.c
@@ -130,7 +130,7 @@ static void *mmap_paddr(intptr_t paddr, uint64_t size)
 	offset = (off_t)paddr % getpagesize();
 	page_addr = (off_t)(paddr - offset);
 
-	hw_addr = (intptr_t *)mmap(0, size, PROT_READ|PROT_WRITE,
+	hw_addr = (intptr_t *)mmap(0, size + offset, PROT_READ|PROT_WRITE,
 					MAP_SHARED, devmem, page_addr);
 	if (hw_addr == MAP_FAILED) {
 		close(devmem);


### PR DESCRIPTION
Fixed libteec function mmap_paddr mmap() size problem reported in [1].

Link: [1] https://github.com/OP-TEE/optee_client/issues/318
Signed-off-by: Yuelei Kan <936115299@qq.com>
Reviewed-by: Etienne Carriere <etienne.carriere@linaro.org>
Acked-by: Jens Wiklander <jens.wiklander@linaro.org>