### PR TITLE
tee-supplicant: Fix atomic operations for secure storage

### DIFF
--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -89,6 +89,17 @@ static size_t tee_fs_get_absolute_filename(char *file, char *out,
 	return (size_t)s;
 }
 
+static void fs_fsync(void)
+{
+	int fd = 0;
+
+	fd = open(tee_fs_root, O_RDONLY | O_DIRECTORY);
+	if (fd > 0) {
+		fsync(fd);
+		close(fd);
+	}
+}
+
 static int do_mkdir(const char *path, mode_t mode)
 {
 	struct stat st;
@@ -101,6 +112,7 @@ static int do_mkdir(const char *path, mode_t mode)
 	if (stat(path, &st) != 0 && !S_ISDIR(st.st_mode))
 		return -1;
 
+	fs_fsync();
 	return 0;
 }
 
@@ -277,6 +289,7 @@ static TEEC_Result ree_fs_new_create(size_t num_params,
 	}
 
 out:
+	fs_fsync();
 	params[2].a = fd;
 	return TEEC_SUCCESS;
 }
@@ -491,6 +504,8 @@ static TEEC_Result ree_fs_new_rename(size_t num_params,
 		if (errno == ENOENT)
 			return TEEC_ERROR_ITEM_NOT_FOUND;
 	}
+
+	fs_fsync();
 	return TEEC_SUCCESS;
 }
 


### PR DESCRIPTION
In order to properly syncronize data for secure storage, fsync must be performed on the containing directory after create, mkdir and rename operations.
This may be especially of interest in a production environment where power may be cut as soon as all the security parameters are saved.

Signed-off-by: Joakim Nordell <joakim.nordell@axis.com>