### PR TITLE
tee-supplicant: fs: no need to use strlen() to check for empty string

### DIFF
--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -628,7 +628,7 @@ TEEC_Result tee_supp_fs_process(size_t num_params,
 	if (!num_params || !tee_supp_param_is_value(params))
 		return TEEC_ERROR_BAD_PARAMETERS;
 
-	if (strlen(tee_fs_root) == 0) {
+	if (!tee_fs_root[0]) {
 		if (tee_supp_fs_init() != 0) {
 			EMSG("error tee_supp_fs_init: failed to create %s/",
 				tee_fs_root);


### PR DESCRIPTION
A string is empty when its first character is zero. Therefore, we can avoid calling strlen() on each FS request.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>