### PR TITLE
teeacl: fix include path

### DIFF
--- a/libteeacl/include/teeacl.h
+++ b/libteeacl/include/teeacl.h
@@ -12,7 +12,7 @@
 #define TEEACL_H
 
 #include <grp.h>
-#include <uuid/uuid.h>
+#include <uuid.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The `uuid` pkg-config file provides the include directory as `${PREFIX}/include/uuid`. Set include path relative to pkg-config file specified include_dir to remain portable.

Signed-off-by: Eero Aaltonen <eero.aaltonen@vaisala.com>

Should fix issue #329