### PR TITLE
fix `ld: cannot find -luuid` for cross building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ LIBDIR ?= /usr/lib
 INCLUDEDIR ?= /usr/include
 
 .PHONY: all build build-libteec build-libckteec build-libseteec \
-	build-libteeacl check-libuuid install copy_export clean cscope \
+	build-libteeacl install copy_export clean cscope \
 	clean-cscope \
 	checkpatch-pre-req checkpatch-modified-patch checkpatch-modified-file \
 	checkpatch-last-commit-patch checkpatch-last-commit-file \
@@ -46,13 +46,9 @@ build-libseteec: build-libteec
 	@echo "Building libseteec.so"
 	@$(MAKE) --directory=libseteec --no-print-directory --no-builtin-variables
 
-build-libteeacl: check-libuuid
+build-libteeacl:
 	@echo "Building libteeacl.so"
 	@$(MAKE) --directory=libteeacl --no-print-directory --no-builtin-variables
-
-check-libuuid:
-	@echo "Finding uuid.pc"
-	$(PKG_CONFIG) --atleast-version=2.34 uuid
 
 install: copy_export
 

--- a/libteeacl/Makefile
+++ b/libteeacl/Makefile
@@ -3,7 +3,7 @@ include ../config.mk
 
 OUT_DIR := $(OO)/libteeacl
 
-.PHONY: all libteeacl clean
+.PHONY: all libteeacl check-libuuid clean
 
 all: libteeacl
 install: libteeacl
@@ -39,6 +39,12 @@ $(LIBTEEACL_OBJ_DIR)/%.o: ${LIBTEEACL_SRC_DIR}/%.c
 	$(VPREFIX)mkdir -p $(LIBTEEACL_OBJ_DIR)
 	@echo "  CC      $<"
 	$(VPREFIX)$(CC) $(LIBTEEACL_CFLAGS) -c $< -o $@
+
+libteeacl: check-libuuid
+
+check-libuuid:
+	@echo "  Finding uuid.pc"
+	$(VPREFIX)$(PKG_CONFIG) --atleast-version=2.34 uuid
 
 libteeacl: $(OUT_DIR)/$(LIBTEEACL_SO_LIBRARY)
 


### PR DESCRIPTION
For cross building, the cross version <CROSS_COMPILE>pkg-config should
be used instead of the native pkg-config.

This is because for the dynamic linking dependency such as
uuid-dev/libuuid, the build machine architecture version should not be
used, instead, the host machine version should be used. Or in other
words, install uuid-dev:arm64 for cross building the aarch64 target on
Debian/Ubuntu.

However, the native pkg-config could not find the correct cross
compiling dependencies if only the target arch uuid-dev is installed.
Even worse, it produces the incorrect LFLAGS without the required -L, if
the native uuid-dev is installed.

By adding multiarch, on Debian/Ubuntu, a <CROSS_COMPILE>pkg-config is
created to correctly handle such problem.

This fixes below issues while cross building.

- If only the target uuid-dev is installed:

  make: *** [Makefile:55: check-libuuid] Error 1

- If both the native and the target uuid-dev are installed:

  ld: cannot find -luuid