### PR TITLE
Add pkgconfig file for libteec

### DIFF
--- a/libteec/CMakeLists.txt
+++ b/libteec/CMakeLists.txt
@@ -35,6 +35,9 @@ endif()
 ################################################################################
 add_library (teec ${SRC})
 
+set(libteectgt teec)
+configure_file(libteec.pc.in libteec.pc @ONLY)
+
 set_target_properties (teec PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	SOVERSION ${PROJECT_VERSION_MAJOR}

--- a/libteec/libteec.pc.in
+++ b/libteec/libteec.pc.in
@@ -1,0 +1,21 @@
+# this template is filled-in by CMake `configure_file(... @ONLY)`
+# the `@....@` are filled in by CMake configure_file(), 
+# from variables set in your CMakeLists.txt or by CMake itself
+#
+# Good tutoral for understanding .pc files: 
+# https://people.freedesktop.org/~dbn/pkg-config-guide.html
+
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Requires: @pc_req_public@
+Requires.private: @pc_req_private@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -l@libteectgt@ 
+Libs.private: -L"${libdir}" -l@libteectgt@ @pc_libs_private@


### PR DESCRIPTION
Autotools build environments that use libteec would benefit from the addition of generated package config files so that libraries could be found wherever they are installed.  Add a teec pkg-config generation to support that

Signed-off-by: Neil Horman <nhorman@gmail.com>