### PR TITLE
Allow cross-compile pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build-libteeacl: check-libuuid
 
 check-libuuid:
 	@echo "Finding uuid.pc"
-	pkg-config --atleast-version=2.34 uuid
+	$(PKG_CONFIG) --atleast-version=2.34 uuid
 
 install: copy_export
 

--- a/flags.mk
+++ b/flags.mk
@@ -5,6 +5,7 @@
 CROSS_COMPILE   ?= arm-linux-gnueabihf-
 CC              ?= $(CROSS_COMPILE)gcc
 AR		?= $(CROSS_COMPILE)ar
+PKG_CONFIG	?= $(CROSS_COMPILE)pkg-config
 
 override CFLAGS += -Wall -Wbad-function-cast -Wcast-align \
 		   -Werror-implicit-function-declaration -Wextra \

--- a/libteeacl/Makefile
+++ b/libteeacl/Makefile
@@ -27,10 +27,10 @@ LIBTEEACL_SRCS	+= tee_uuid.c
 LIBTEEACL_INCLUDES	= ${CURDIR}/include
 
 LIBTEEACL_CFLAGS	:= $(addprefix -I, $(LIBTEEACL_INCLUDES)) \
-			$(shell pkg-config --cflags uuid) \
+			$(shell $(PKG_CONFIG) --cflags uuid) \
 			$(CFLAGS) -D_GNU_SOURCE -fPIC
 
-LIBTEEACL_LFLAGS	:= $(LDFLAGS) $(shell pkg-config --libs uuid)
+LIBTEEACL_LFLAGS	:= $(LDFLAGS) $(shell $(PKG_CONFIG) --libs uuid)
 
 LIBTEEACL_OBJ_DIR	:= $(OUT_DIR)
 LIBTEEACL_OBJS	:= $(patsubst %.c,$(LIBTEEACL_OBJ_DIR)/%.o, $(LIBTEEACL_SRCS))


### PR DESCRIPTION
optee-client fails to cross build from source. This commit apply CROSS_COMPILE on pkg-config to let it be able to build by cross-compiler.

Signed-off-by: Helmut Grohne <helmut@subdivi.de>
Signed-off-by: Ying-Chun Liu (PaulLiu) <paul.liu@linaro.org>