### PR TITLE
Correct some pkgconfig file errors

### DIFF
--- a/libteec/CMakeLists.txt
+++ b/libteec/CMakeLists.txt
@@ -2,6 +2,9 @@ project(libteec
 	VERSION 1.0.0
 	LANGUAGES C)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(JoinPaths)
+
 ################################################################################
 # Packages
 ################################################################################
@@ -35,6 +38,8 @@ endif()
 ################################################################################
 add_library (teec ${SRC})
 
+join_paths(teec_libdir "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+join_paths(teec_incdir "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
 set(libteectgt teec)
 configure_file(libteec.pc.in libteec.pc @ONLY)
 

--- a/libteec/cmake/JoinPaths.cmake
+++ b/libteec/cmake/JoinPaths.cmake
@@ -1,0 +1,24 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/libteec/libteec.pc.in
+++ b/libteec/libteec.pc.in
@@ -6,16 +6,12 @@
 # https://people.freedesktop.org/~dbn/pkg-config-guide.html
 
 prefix="@CMAKE_INSTALL_PREFIX@"
-exec_prefix="${prefix}"
-libdir="${prefix}/lib"
-includedir="${prefix}/include"
-
+teec_incdir = "@teec_incdir@"
+teec_libdir = "@teec_libdir@"
+ 
 Name: @PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@
 URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Requires: @pc_req_public@
-Requires.private: @pc_req_private@
-Cflags: -I"${includedir}"
-Libs: -L"${libdir}" -l@libteectgt@ 
-Libs.private: -L"${libdir}" -l@libteectgt@ @pc_libs_private@
+Cflags: -I"${teec_incdir}"
+Libs: -L"${teec_libdir}" -l@libteectgt@ 


### PR DESCRIPTION
@eli-schwartz noted a few shortocomings in the pkgconfig file added in PR 334:
* Failure to honor CMAKE_INSTALL_LIBDIR/CMAKE_INSTALL_INCLUDEDIR
* duplication of ldflags in the Libs.private section

This PR fixes those, by:
* Using cmake_path to construct the full lib/include paths prior to doing macro expansion on the pc.in file
* removing the duplication library flags in the private section for static linking

Signed-off-by: Neil Horman <nhorman@gmail.com>