### PR TITLE
ci: add GitHub Actions script and Docker files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+on: [push, pull_request]
+permissions:
+  contents: read # to fetch code (actions/checkout)
+jobs:
+  debian:
+    name: build (Debian)
+    runs-on: ubuntu-latest
+    container: jforissier/optee_client_ci_debian
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: arm64 with make
+        run: make -j O=out-make-aarch64 CROSS_COMPILE=aarch64-linux-gnu-
+      - name: armhf with make
+        run: make -j O=out-make-armhf CROSS_COMPILE=arm-linux-gnueabihf-
+      - name: arm64 with cmake
+        run: |
+          set -e -v
+          mkdir out-cmake-aarch64 && cd out-cmake-aarch64
+          PKG_CONFIG=aarch64-linux-gnu-pkg-config cmake .. -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc
+          make -j
+      - name: armhf with cmake
+        run: |
+          set -e -v
+          mkdir out-cmake-armhf && cd out-cmake-armhf
+          PKG_CONFIG=arm-linux-gnueabihf-pkg-config cmake .. -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc
+          make -j
+  ubuntu:
+    name: build (Ubuntu)
+    runs-on: ubuntu-latest
+    container: jforissier/optee_client_ci_ubuntu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: arm64 with make
+        run: make -j O=out-make-aarch64 CROSS_COMPILE=aarch64-linux-gnu-
+      - name: armhf with make
+        run: make -j O=out-make-armhf CROSS_COMPILE=arm-linux-gnueabihf-
+      - name: arm64 with cmake
+        run: |
+          set -e -v
+          mkdir out-cmake-aarch64 && cd out-cmake-aarch64
+          PKG_CONFIG=aarch64-linux-gnu-pkg-config cmake .. -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc
+          make -j
+      - name: armhf with cmake
+        run: |
+          set -e -v
+          mkdir out-cmake-armhf && cd out-cmake-armhf
+          PKG_CONFIG=arm-linux-gnueabihf-pkg-config cmake .. -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc
+          make -j

--- a/ci/Dockerfile.debian
+++ b/ci/Dockerfile.debian
@@ -1,0 +1,21 @@
+# Dockerfile for CI image used in ../.github/workflows/ci.yml
+
+FROM debian:bullseye-slim
+MAINTAINER Jerome Forissier <jerome.forissier@linaro.org>
+
+ENV LANG=C.UTF-8
+
+RUN dpkg --add-architecture armhf
+RUN dpkg --add-architecture arm64
+
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -y \
+  cmake \
+  dpkg-dev \
+  gcc-aarch64-linux-gnu \
+  gcc-arm-linux-gnueabihf \
+  make \
+  pkg-config \
+  uuid-dev:armhf \
+  uuid-dev:arm64

--- a/ci/Dockerfile.ubuntu
+++ b/ci/Dockerfile.ubuntu
@@ -1,0 +1,30 @@
+# Dockerfile for CI image used in ../.github/workflows/ci.yml
+
+FROM ubuntu:22.04
+MAINTAINER Jerome Forissier <jerome.forissier@linaro.org>
+
+ENV LANG=C.UTF-8
+
+RUN dpkg --add-architecture armhf
+RUN dpkg --add-architecture arm64
+
+RUN echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse' > /etc/apt/sources.list
+RUN echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse' >> /etc/apt/sources.list
+RUN echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse' >> /etc/apt/sources.list
+RUN echo 'deb [arch=amd64] http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse' >> /etc/apt/sources.list
+RUN echo 'deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe multiverse' >> /etc/apt/sources.list
+RUN echo 'deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe multiverse' >> /etc/apt/sources.list
+RUN echo 'deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse' >> /etc/apt/sources.list
+RUN echo 'deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe multiverse' >> /etc/apt/sources.list
+
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -y \
+  cmake \
+  dpkg-dev \
+  gcc-aarch64-linux-gnu \
+  gcc-arm-linux-gnueabihf \
+  make \
+  pkg-config \
+  uuid-dev:armhf \
+  uuid-dev:arm64


### PR DESCRIPTION
Adds a CI script to be run on push and pull requests. Eight cross-builds are checked: (armhf, aarch64) x (make, cmake) x (x86 Debian, x86 Ubuntu).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>