### PR TITLE
Fix uClibc reallocarray compilation failure and also clang compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,13 @@ add_compile_options (
 	-Wmissing-format-attribute -Wmissing-include-dirs
 	-Wmissing-noreturn -Wmissing-prototypes -Wnested-externs
 	-Wpointer-arith -Wshadow -Wstrict-prototypes
-	-Wswitch-default -Wunsafe-loop-optimizations
-	-Wwrite-strings -fPIC
+	-Wswitch-default -Wwrite-strings -fPIC
 )
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+    add_compile_options(
+        -Wunsafe-loop-optimizations
+    )
+endif()
 if(CFG_WERROR)
     add_compile_options(-Werror)
 endif(CFG_WERROR)

--- a/flags.mk
+++ b/flags.mk
@@ -7,6 +7,8 @@ CC              ?= $(CROSS_COMPILE)gcc
 AR		?= $(CROSS_COMPILE)ar
 PKG_CONFIG	?= $(CROSS_COMPILE)pkg-config
 
+C_COMPILER=$(shell readlink -f $$(which $(CC)))
+
 override CFLAGS += -Wall -Wbad-function-cast -Wcast-align \
 		   -Werror-implicit-function-declaration -Wextra \
 		   -Wfloat-equal -Wformat-nonliteral -Wformat-security \
@@ -14,8 +16,10 @@ override CFLAGS += -Wall -Wbad-function-cast -Wcast-align \
 		   -Wmissing-format-attribute -Wmissing-include-dirs \
 		   -Wmissing-noreturn -Wmissing-prototypes -Wnested-externs \
 		   -Wpointer-arith -Wshadow -Wstrict-prototypes \
-		   -Wswitch-default -Wunsafe-loop-optimizations \
-		   -Wwrite-strings -D_FILE_OFFSET_BITS=64
+		   -Wswitch-default -Wwrite-strings -D_FILE_OFFSET_BITS=64
+ifneq (,$(findstring gcc,$(C_COMPILER)))
+override CFLAGS	+= -Wunsafe-loop-optimizations
+endif
 ifeq ($(CFG_WERROR),y)
 override CFLAGS	+= -Werror
 endif

--- a/libteeacl/src/group.c
+++ b/libteeacl/src/group.c
@@ -72,7 +72,8 @@ enum rv_groupmember teeacl_user_is_member_of(const char *user, gid_t group)
 	if (ret == -1) {
 		p_groups = groups;
 
-		groups = reallocarray(groups, grouplistsize, sizeof(gid_t));
+		/* we use realloc, since uClibc does not implement reallocarray */
+		groups = realloc(groups, grouplistsize * sizeof(gid_t));
 		if (!groups) {
 			free(p_groups);
 			return E_MEMORY;


### PR DESCRIPTION
Build failure in http://autobuild.buildroot.net/results/9bda046c3af43765edbc27e2e3c9b6d4a635eef7 (issue #339) seems to be due to uClibc not implementing `reallocarray`. Use `realloc` instead and make the reason explicit.

Also included fix for making compile options clang friendly

