### PR TITLE
tee-supplicant: Allow to control RPMB emulation during runtime

### DIFF
--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -3,7 +3,7 @@ include ../config.mk
 
 OUT_DIR := $(OO)/tee-supplicant
 
-# Emulate RPMB ioctl's by default
+# Support RPMB emulation by default (--rpmb-emu command line argument)
 RPMB_EMU	?= 1
 
 .PHONY: all tee-supplicant clean

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -493,6 +493,9 @@ static int usage(int status)
 	fprintf(stderr, "\t-h, --help: this help\n");
 	fprintf(stderr, "\t-d, --daemonize: run as a daemon (fork and return "
 			"after child has opened the TEE device or on error)\n");
+#ifdef RPMB_EMU
+	fprintf(stderr, "\t-e, --rpmb-emu: use emulated RPMB\n");
+#endif
 	fprintf(stderr, "\t-f, --fs-parent-path: secure fs parent path [%s]\n",
 			supplicant_params.fs_parent_path);
 	fprintf(stderr, "\t-t, --ta-dir: TAs dirname under %s [%s]\n", TEEC_LOAD_PATH,
@@ -808,6 +811,9 @@ int main(int argc, char *argv[])
 		/* long name      | has argument  | flag | short value */
 		{ "help",            no_argument,       0, 'h' },
 		{ "daemonize",       no_argument,       0, 'd' },
+#ifdef RPMB_EMU
+		{ "rpmb-emu",        no_argument,       0, 'e' },
+#endif
 		{ "fs-parent-path",  required_argument, 0, 'f' },
 		{ "ta-dir",          required_argument, 0, 't' },
 		{ "plugin-path",     required_argument, 0, 'p' },
@@ -815,7 +821,7 @@ int main(int argc, char *argv[])
 		{ 0, 0, 0, 0 }
 	};
 
-	while ((opt = getopt_long(argc, argv, "hdf:t:p:r:",
+	while ((opt = getopt_long(argc, argv, "hdef:t:p:r:",
 				long_options, &long_index )) != -1) {
 		switch (opt) {
 			case 'h' :
@@ -824,6 +830,11 @@ int main(int argc, char *argv[])
 			case 'd':
 				daemonize = true;
 				break;
+#ifdef RPMB_EMU
+			case 'e':
+				supplicant_params.rpmb_emu = true;
+				break;
+#endif
 			case 'f':
 				supplicant_params.fs_parent_path = optarg;
 				break;

--- a/tee-supplicant/src/tee_supplicant.h
+++ b/tee-supplicant/src/tee_supplicant.h
@@ -44,6 +44,9 @@ struct tee_supplicant_params {
     const char *plugin_load_path;
     const char *fs_parent_path;
     const char *rpmb_cid;
+#ifdef RPMB_EMU
+    bool rpmb_emu;
+#endif
 };
 
 extern struct tee_supplicant_params supplicant_params;


### PR DESCRIPTION
This permits to build with RPMB_EMU=1 without breaking real usage. Specifically helpful for distros. Closes #353.

Still testing, thus "draft".
