### PR TITLE
tee-supplicant: Enable command line support for RPMB_EMU

### DIFF
--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -4,7 +4,6 @@ project (tee-supplicant C)
 # Configuration flags always included
 ################################################################################
 option (CFG_TA_TEST_PATH "Enable tee-supplicant to load from test/debug path" OFF)
-option (RPMB_EMU "Enable tee-supplicant to emulate RPMB" ON)
 option (CFG_TA_GPROF_SUPPORT "Enable tee-supplicant support for TAs instrumented with gprof" ON)
 option (CFG_FTRACE_SUPPORT "Enable tee-supplicant support for TAs instrumented with ftrace" ON)
 option (CFG_TEE_SUPP_PLUGINS "Enable tee-supplicant plugin support" ON)
@@ -72,11 +71,6 @@ endif()
 if (CFG_TA_TEST_PATH)
 	target_compile_definitions (${PROJECT_NAME}
 		PRIVATE -DCFG_TA_TEST_PATH=${CFG_TA_TEST_PATH})
-endif()
-
-if (RPMB_EMU)
-	target_compile_definitions (${PROJECT_NAME}
-		PRIVATE -DRPMB_EMU=1)
 endif()
 
 if (CFG_TA_GPROF_SUPPORT)

--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -3,9 +3,6 @@ include ../config.mk
 
 OUT_DIR := $(OO)/tee-supplicant
 
-# Emulate RPMB ioctl's by default
-RPMB_EMU	?= 1
-
 .PHONY: all tee-supplicant clean
 
 all: tee-supplicant
@@ -24,9 +21,8 @@ ifeq ($(CFG_GP_SOCKETS),y)
 TEES_SRCS 	+= tee_socket.c
 endif
 
-ifeq ($(RPMB_EMU),1)
 TEES_SRCS	+= sha2.c hmac_sha2.c
-endif
+
 ifneq (,$(filter y,$(CFG_TA_GPROF_SUPPORT) $(CFG_FTRACE_SUPPORT)))
 TEES_SRCS	+= prof.c
 endif
@@ -50,9 +46,6 @@ TEES_CFLAGS	:= $(addprefix -I, $(TEES_INCLUDES)) $(CFLAGS) \
 
 ifeq ($(CFG_GP_SOCKETS),y)
 TEES_CFLAGS	+= -DCFG_GP_SOCKETS=1
-endif
-ifeq ($(RPMB_EMU),1)
-TEES_CFLAGS	+= -DRPMB_EMU=1
 endif
 ifeq ($(CFG_TA_TEST_PATH),y)
 TEES_CFLAGS	+= -DCFG_TA_TEST_PATH=1

--- a/tee-supplicant/src/rpmb.h
+++ b/tee-supplicant/src/rpmb.h
@@ -34,4 +34,6 @@
 uint32_t rpmb_process_request(void *req, size_t req_size, void *rsp,
 			      size_t rsp_size);
 
+int rpmb_init(void);
+
 #endif /* RPMB_H */

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -493,6 +493,7 @@ static int usage(int status)
 	fprintf(stderr, "\t-h, --help: this help\n");
 	fprintf(stderr, "\t-d, --daemonize: run as a daemon (fork and return "
 			"after child has opened the TEE device or on error)\n");
+	fprintf(stderr, "\t-e, --rpmb-emu-disable: RPMB emunation disable\n");
 	fprintf(stderr, "\t-f, --fs-parent-path: secure fs parent path [%s]\n",
 			supplicant_params.fs_parent_path);
 	fprintf(stderr, "\t-t, --ta-dir: TAs dirname under %s [%s]\n", TEEC_LOAD_PATH,
@@ -808,6 +809,7 @@ int main(int argc, char *argv[])
 		/* long name      | has argument  | flag | short value */
 		{ "help",            no_argument,       0, 'h' },
 		{ "daemonize",       no_argument,       0, 'd' },
+		{ "rpmb-emu-disable", no_argument,      0, 'e' },
 		{ "fs-parent-path",  required_argument, 0, 'f' },
 		{ "ta-dir",          required_argument, 0, 't' },
 		{ "plugin-path",     required_argument, 0, 'p' },
@@ -815,7 +817,7 @@ int main(int argc, char *argv[])
 		{ 0, 0, 0, 0 }
 	};
 
-	while ((opt = getopt_long(argc, argv, "hdf:t:p:r:",
+	while ((opt = getopt_long(argc, argv, "hde:f:t:p:r:",
 				long_options, &long_index )) != -1) {
 		switch (opt) {
 			case 'h' :
@@ -823,6 +825,9 @@ int main(int argc, char *argv[])
 				break;
 			case 'd':
 				daemonize = true;
+				break;
+			case 'e':
+				supplicant_params.rpmb_emu_disable = true;
 				break;
 			case 'f':
 				supplicant_params.fs_parent_path = optarg;
@@ -894,6 +899,8 @@ int main(int argc, char *argv[])
 		}
 		close(pipefd[1]);
 	}
+
+	rpmb_init();
 
 	while (!arg.abort) {
 		if (!process_one_request(&arg))

--- a/tee-supplicant/src/tee_supplicant.h
+++ b/tee-supplicant/src/tee_supplicant.h
@@ -44,6 +44,7 @@ struct tee_supplicant_params {
     const char *plugin_load_path;
     const char *fs_parent_path;
     const char *rpmb_cid;
+    bool rpmb_emu_disable;
 };
 
 extern struct tee_supplicant_params supplicant_params;

--- a/tee-supplicant/tee_supplicant_android.mk
+++ b/tee-supplicant/tee_supplicant_android.mk
@@ -30,11 +30,7 @@ LOCAL_SRC_FILES += src/tee_socket.c
 LOCAL_CFLAGS += -DCFG_GP_SOCKETS=1
 endif
 
-RPMB_EMU ?= 1
-ifeq ($(RPMB_EMU),1)
 LOCAL_SRC_FILES += src/sha2.c src/hmac_sha2.c
-LOCAL_CFLAGS += -DRPMB_EMU=1
-endif
 
 ifneq (,$(filter y,$(CFG_TA_GPROF_SUPPORT) $(CFG_FTRACE_SUPPORT)))
 LOCAL_SRC_FILES += src/prof.c


### PR DESCRIPTION
The current eMMC RPMB support is enabled with RPMB_EMU=1 by default at compiling time and needs re-compiling to access real eMMC RPMB. It's inconvenient especially when this package is provided by known Linux distributions like Ubuntu. This commit enhances it by adding command line option for RPMB_EMU. It still uses RPMB emulation by default to be backwoard compatible, but could use '--rpmb-emu-disable' to access the actual eMMC RPMB.