### PR TITLE
tee-supplicant: Cleanup TEEC_TEST_LOAD_PATH

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -9,7 +9,6 @@ CFG_TEE_SUPP_LOG_LEVEL ?= 2
 
 # Define Android-specific configuration before including config.mk
 CFG_TEE_CLIENT_LOAD_PATH ?= /vendor/lib
-TEEC_TEST_LOAD_PATH ?= /data/vendor/tee
 CFG_TEE_FS_PARENT_PATH ?= /data/vendor/tee
 CFG_TEE_SUPP_PLUGINS ?= y
 ifneq ($(strip $($(combo_2nd_arch_prefix)TARGET_TOOLS_PREFIX)),)

--- a/config.mk
+++ b/config.mk
@@ -44,12 +44,6 @@ CFG_TEE_SUPP_PLUGINS ?= y
 #   The location of the user plugins
 CFG_TEE_PLUGIN_LOAD_PATH ?= /usr/lib/tee-supplicant/plugins/
 
-# CFG_TA_TEST_PATH
-#   Enable the tee test path.  When enabled, the supplicant will try
-#   loading from a debug path before the regular path.  This allows test
-#   such as 1008.5 that test loading of corrupt TAs.
-CFG_TA_TEST_PATH ?= n
-
 # CFG_GP_SOCKETS
 #   Enable Global Platform Sockets support
 CFG_GP_SOCKETS ?= y

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -3,7 +3,6 @@ project(tee-supplicant C)
 ################################################################################
 # Configuration flags always included
 ################################################################################
-option(CFG_TA_TEST_PATH "Enable tee-supplicant to load from test/debug path" OFF)
 option(RPMB_EMU "Enable tee-supplicant to emulate RPMB" ON)
 option(CFG_TA_GPROF_SUPPORT "Enable tee-supplicant support for TAs instrumented with gprof" ON)
 option(CFG_FTRACE_SUPPORT "Enable tee-supplicant support for TAs instrumented with ftrace" ON)
@@ -67,11 +66,6 @@ target_compile_definitions(${PROJECT_NAME}
 if(CFG_GP_SOCKETS)
 	target_compile_definitions(${PROJECT_NAME}
 		PRIVATE -DCFG_GP_SOCKETS=${CFG_GP_SOCKETS})
-endif()
-
-if(CFG_TA_TEST_PATH)
-	target_compile_definitions(${PROJECT_NAME}
-		PRIVATE -DCFG_TA_TEST_PATH=${CFG_TA_TEST_PATH})
 endif()
 
 if(RPMB_EMU)

--- a/tee-supplicant/Makefile
+++ b/tee-supplicant/Makefile
@@ -54,9 +54,6 @@ endif
 ifeq ($(RPMB_EMU),1)
 TEES_CFLAGS	+= -DRPMB_EMU=1
 endif
-ifeq ($(CFG_TA_TEST_PATH),y)
-TEES_CFLAGS	+= -DCFG_TA_TEST_PATH=1
-endif
 TEES_FILE	:= $(OUT_DIR)/$(PACKAGE_NAME)
 TEES_LFLAGS    := $(LDFLAGS) -L$(OUT_DIR)/../libteec -lteec
 

--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -696,17 +696,11 @@ static void *thread_main(void *a)
 	return NULL;
 }
 
-#define TEEC_TEST_LOAD_PATH "/foo:/bar::/baz"
-
 static void set_ta_path(void)
 {
 	char *p = NULL;
 	char *saveptr = NULL;
-	const char *path = (char *)
-#ifdef TEEC_TEST_LOAD_PATH
-		TEEC_TEST_LOAD_PATH ":"
-#endif
-		TEEC_LOAD_PATH;
+	const char *path = (char *)TEEC_LOAD_PATH;
 	size_t n = 0;
 
 	ta_path_str = strdup(path);

--- a/tee-supplicant/src/teec_ta_load.c
+++ b/tee-supplicant/src/teec_ta_load.c
@@ -36,22 +36,6 @@
 #include <teec_trace.h>
 #include <teec_ta_load.h>
 
-/*
- * Attempt to first load TAs from a writable directory.  This is
- * intended for testing (xtest 1008, load_corrupt_ta specifically),
- * and should not be enabled in a production system, as it would
- * greatly facilitate loading rogue TA code.
- */
-#ifdef CFG_TA_TEST_PATH
-# ifndef TEEC_TEST_LOAD_PATH
-#  ifdef __ANDROID__
-#   define TEEC_TEST_LOAD_PATH "/data/vendor/tee"
-#  else
-#   define TEEC_TEST_LOAD_PATH "/tmp"
-#  endif
-# endif
-#endif
-
 #ifndef PATH_MAX
 #define PATH_MAX 255
 #endif

--- a/tee-supplicant/tee_supplicant_android.mk
+++ b/tee-supplicant/tee_supplicant_android.mk
@@ -11,14 +11,6 @@ LOCAL_CFLAGS += -DDEBUGLEVEL_$(CFG_TEE_SUPP_LOG_LEVEL) \
 		-DTEE_FS_PARENT_PATH=\"$(CFG_TEE_FS_PARENT_PATH)\" \
 		-DTEEC_LOAD_PATH=\"$(CFG_TEE_CLIENT_LOAD_PATH)\"
 
-ifneq ($(TEEC_TEST_LOAD_PATH),)
-LOCAL_CFLAGS += -DTEEC_TEST_LOAD_PATH=\"$(TEEC_TEST_LOAD_PATH)\"
-endif
-
-ifeq ($(CFG_TA_TEST_PATH),y)
-LOCAL_CFLAGS += -DCFG_TA_TEST_PATH=1
-endif
-
 LOCAL_SRC_FILES += src/tee_supplicant.c \
 		   src/teec_ta_load.c \
 		   src/tee_supp_fs.c \


### PR DESCRIPTION
Cleanup TEEC_TEST_LOAD_PATH and CFG_TA_TEST_PATH, as the TEEC_TEST_LOAD_PATH was not working properly anyway.