### PR TITLE
tee-supplicant: Allow for TA load path to be specified at runtime

### DIFF
--- a/tee-supplicant/src/tee_supplicant.h
+++ b/tee-supplicant/src/tee_supplicant.h
@@ -41,6 +41,7 @@ struct tee_ioctl_param;
 /* Global tee-supplicant parameters */
 struct tee_supplicant_params {
     const char *ta_dir;
+    const char *ta_load_path;
     const char *plugin_load_path;
     const char *fs_parent_path;
     const char *rpmb_cid;

--- a/tee-supplicant/src/teec_ta_load.c
+++ b/tee-supplicant/src/teec_ta_load.c
@@ -51,9 +51,8 @@ struct tee_rpc_cmd {
  * Based on the uuid this function will try to find a TA-binary on the
  * filesystem and return it back to the caller in the parameter ta.
  *
- * @param: prefix       Prefix for TA load path
- * @param: dev_path     Where to load the TA from. The full path to the TA
- *                      binary is @prefix/@dev_path/@destination.ta.
+ * @param: ta_load_path Where to load the TA from. The full path to the TA
+ *                      binary is @ta_load_path/@destination.ta.
  * @param: destination  The uuid of the TA we are searching for.
  * @param: ta           A pointer which this function will allocate and copy
  *                      the TA from the filesystem to the pointer itself. It is
@@ -63,8 +62,7 @@ struct tee_rpc_cmd {
  *
  * @return              0 if TA was found, otherwise -1.
  */
-static int try_load_secure_module(const char* prefix,
-				  const char* dev_path,
+static int try_load_secure_module(const char *ta_load_path,
 				  const TEEC_UUID *destination, void *ta,
 				  size_t *ta_size)
 {
@@ -88,8 +86,8 @@ static int try_load_secure_module(const char* prefix,
 	 */
 again:
 	n = snprintf(fname, PATH_MAX,
-		     "%s/%s/%08x-%04x-%04x-%02x%02x%s%02x%02x%02x%02x%02x%02x.ta",
-		     prefix, dev_path,
+		     "%s/%08x-%04x-%04x-%02x%02x%s%02x%02x%02x%02x%02x%02x.ta",
+		     ta_load_path,
 		     destination->timeLow,
 		     destination->timeMid,
 		     destination->timeHiAndVersion,
@@ -159,16 +157,14 @@ out:
 	return TA_BINARY_FOUND;
 }
 
-int TEECI_LoadSecureModule(const char* dev_path,
-			   const TEEC_UUID *destination, void *ta,
+int TEECI_LoadSecureModule(const TEEC_UUID *destination, void *ta,
 			   size_t *ta_size)
 {
 	int res = TA_BINARY_NOT_FOUND;
 	char **path = NULL;
 
 	for (path = ta_path; *path; path++) {
-		res = try_load_secure_module(*path, dev_path, destination, ta,
-					     ta_size);
+		res = try_load_secure_module(*path, destination, ta, ta_size);
 		if (res == TA_BINARY_FOUND)
 			break;
 	}

--- a/tee-supplicant/src/teec_ta_load.h
+++ b/tee-supplicant/src/teec_ta_load.h
@@ -31,9 +31,7 @@
 #define TA_BINARY_FOUND 0
 #define TA_BINARY_NOT_FOUND -1
 
-/* Heap copy of TA load paths, separated by '\0' (access via ta_path) */
-extern char *ta_path_str;
-/* NULL-terminated list of paths (pointers into ta_path_str) */
+/* NULL-terminated list of paths */
 extern char **ta_path;
 
 /**
@@ -49,7 +47,6 @@ extern char **ta_path;
  *
  * @return              0 if TA was found, otherwise -1.
  */
-int TEECI_LoadSecureModule(const char *name,
-			   const TEEC_UUID *destination, void *ta,
+int TEECI_LoadSecureModule(const TEEC_UUID *destination, void *ta,
 			   size_t *ta_size);
 #endif


### PR DESCRIPTION
Add a new `--ta-path` CLI flag for overriding the default load path used by tee-supplicant. The given path string can be a set of colon (':') separated paths, each being a full path used when searching for TAs. When this option is not used, the existing behavior of loading TAs from a subdirectory "ta-dir" under TEEC_LOAD_PATH is retained.