### PR TITLE
teec: do fail on MAX_SIZE allocation requests

### DIFF
--- a/libteec/src/tee_client_api.c
+++ b/libteec/src/tee_client_api.c
@@ -82,7 +82,7 @@ static void *teec_paged_aligned_alloc(size_t sz)
 	size_t page_sz = sysconf(_SC_PAGESIZE);
 	size_t aligned_sz = ((sz + page_sz - 1) / page_sz) * page_sz;
 
-	if (!posix_memalign(&p, page_sz, aligned_sz))
+	if (aligned_sz >= sz && !posix_memalign(&p, page_sz, aligned_sz))
 		return p;
 
 	return NULL;


### PR DESCRIPTION
The variable aligned_sz will be 0 when the requested sz is MAX_SIZE. Since posix_memalign can return a valid pointer for zero size allocations, share memory registration requests for MAX_SIZE might make it to the kernel.

This PR stops it early - just as it was before "teec: use multiple of page size for page aligned buffers" was merged.

Fixes: acb0885c117e73cb6c5c9b1dd9054cb3f93507ee ("teec: use multiple of page size for page aligned buffers")