### PR TITLE
libckteec: one shot encryption/decryption may have no input data

### DIFF
--- a/libckteec/src/pkcs11_processing.c
+++ b/libckteec/src/pkcs11_processing.c
@@ -262,10 +262,12 @@ CK_RV ck_encdecrypt_oneshot(CK_SESSION_HANDLE session,
 	memcpy(ctrl->buffer, &session_handle, sizeof(session_handle));
 
 	/* Shm io1: input data buffer */
-	in_shm = ckteec_register_shm(in, in_len, CKTEEC_SHM_IN);
-	if (!in_shm) {
-		rv = CKR_HOST_MEMORY;
-		goto bail;
+	if (in) {
+		in_shm = ckteec_register_shm(in, in_len, CKTEEC_SHM_IN);
+		if (!in_shm) {
+			rv = CKR_HOST_MEMORY;
+			goto bail;
+		}
 	}
 
 	/* Shm io2: output data buffer */


### PR DESCRIPTION
Change the one shot encryption and decryption handler function to allow input buffer reference to be NULL. This may happen for example with AES GCM operation where encryption of a NULL buffer is expected to produce an AES GCM authentication tag. Before this change, providing a NULL buffer to C_Encrypt() made ckteec_register_shm() to fail and ckteec_register_shm() to return CKR_HOST_MEMORY error code.

Fixes: aa3dd58d605e ("libckteec: Allow 0 length input buffer  for update operations;")