### PR TITLE
tee-supplicant: Fix crash when TA isn't found.

### DIFF
--- a/tee-supplicant/src/tee_supplicant.c
+++ b/tee-supplicant/src/tee_supplicant.c
@@ -722,7 +722,7 @@ static void set_ta_path(void)
 	}
 	n++; /* NULL terminator */
 
-	ta_path = malloc(n * sizeof(char *));
+	ta_path = calloc(n, sizeof(char *));
 	if (!ta_path)
 		goto err;
 


### PR DESCRIPTION
In this PR , it fixes bug mentioned in #374.

fixes #374 