### PR TITLE
tee-supplicant: remove useless use of __ANDROID__ condition

### DIFF
--- a/tee-supplicant/src/rpmb.c
+++ b/tee-supplicant/src/rpmb.c
@@ -160,11 +160,7 @@ static int mmc_rpmb_fd(uint16_t dev_id)
 
 	DMSG("dev_id = %u", dev_id);
 	if (fd < 0) {
-#ifdef __ANDROID__
 		snprintf(path, sizeof(path), "/dev/mmcblk%urpmb", dev_id);
-#else
-		snprintf(path, sizeof(path), "/dev/mmcblk%urpmb", dev_id);
-#endif
 		fd = open(path, O_RDWR);
 		if (fd < 0) {
 			EMSG("Could not open %s (%s)", path, strerror(errno));


### PR DESCRIPTION
Since commit 37975f1ba31e ("rmpb: update AOSP RPMB device path") the RPMB device patch is the same __ANDROID__ directive being set or not hence simplify the implementation by removing use of that directive.