### PR TITLE
libckteec: support for CKM_RSA_X_509

### DIFF
--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -768,6 +768,7 @@ CK_RV serialize_ck_mecha_params(struct serializer *obj,
 	case CKM_ECDSA_SHA512:
 	case CKM_RSA_PKCS_KEY_PAIR_GEN:
 	case CKM_RSA_PKCS:
+	case CKM_RSA_X_509:
 	case CKM_MD5_RSA_PKCS:
 	case CKM_SHA1_RSA_PKCS:
 	case CKM_SHA224_RSA_PKCS:


### PR DESCRIPTION
Define CKM_RSA_X_509 mechanism identifier to allow client to request operations with this mechanism.

Related to https://github.com/OP-TEE/optee_os/pull/7030.