### PR TITLE
tee-supplicant: add sd_notify.c to Android.bp sources

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -281,6 +281,7 @@ cc_binary {
     srcs: [
         "tee-supplicant/src/handle.c",
         "tee-supplicant/src/rpmb.c",
+        "tee-supplicant/src/sd_notify.c",
         "tee-supplicant/src/tee_supp_fs.c",
         "tee-supplicant/src/tee_supplicant.c",
         "tee-supplicant/src/teec_ta_load.c",


### PR DESCRIPTION
Fixes the following link error:
```
ld.lld: error: undefined symbol: sd_notify_ready
>>> referenced by tee_supplicant.c:928 (vendor/linaro/optee_client/tee-supplicant/src/tee_supplicant.c:928)
```

Fixes: a5b1ffc ("tee-supplicant: send READY=1 notification to systemd")