### PR TITLE
tee-supplicant: add udev rule and systemd service file

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -23,7 +23,7 @@ CFG_TEE_SUPP_LOG_LEVEL?=1
 #   This folder can be created with the required permission in an init
 #   script during boot, else it will be created by the tee-supplicant on
 #   first REE FS access.
-CFG_TEE_FS_PARENT_PATH ?= /data/tee
+CFG_TEE_FS_PARENT_PATH ?= /var/lib/tee
 
 # CFG_TEE_CLIENT_LOG_FILE
 #   The location of the client log file when logging to file is enabled.

--- a/libteec/CMakeLists.txt
+++ b/libteec/CMakeLists.txt
@@ -62,8 +62,6 @@ target_link_libraries(teec
 ################################################################################
 # Install targets
 ################################################################################
-# FIXME: This should in someway harmonize with CFG_TEE_CLIENT_LOAD_PATH
-# FIXME: Should we change this to /usr/local/lib?
 install(TARGETS teec LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
                       ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 

--- a/libteec/CMakeLists.txt
+++ b/libteec/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # Configuration flags always included
 ################################################################################
 set(CFG_TEE_CLIENT_LOG_LEVEL "1" CACHE STRING "libteec log level")
-set(CFG_TEE_CLIENT_LOG_FILE "/data/tee/teec.log" CACHE STRING "Location of libteec log")
+set(CFG_TEE_CLIENT_LOG_FILE "${CMAKE_INSTALL_LOCALSTATEDIR}/lib/tee/teec.log" CACHE STRING "Location of libteec log")
 
 ################################################################################
 # Source files

--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -11,10 +11,15 @@ option(CFG_TEE_SUPP_PLUGINS "Enable tee-supplicant plugin support" ON)
 set(CFG_TEE_SUPP_LOG_LEVEL "1" CACHE STRING "tee-supplicant log level")
 # FIXME: Question is, is this really needed? Should just use defaults from # GNUInstallDirs?
 set(CFG_TEE_CLIENT_LOAD_PATH "/lib" CACHE STRING "Colon-separated list of paths where to look for TAs (see also --ta-dir)")
-set(CFG_TEE_FS_PARENT_PATH "/data/tee" CACHE STRING "Location of TEE filesystem (secure storage)")
+set(CFG_TEE_FS_PARENT_PATH "${CMAKE_INSTALL_LOCALSTATEDIR}/lib/tee" CACHE STRING "Location of TEE filesystem (secure storage)")
 # FIXME: Why do we have if defined(CFG_GP_SOCKETS) && CFG_GP_SOCKETS == 1 in the c-file?
 set(CFG_GP_SOCKETS "1" CACHE STRING "Enable GlobalPlatform Socket API support")
-set(CFG_TEE_PLUGIN_LOAD_PATH "/usr/lib/tee-supplicant/plugins/" CACHE STRING "tee-supplicant's plugins path")
+set(CFG_TEE_PLUGIN_LOAD_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/plugins/" CACHE STRING "tee-supplicant's plugins path")
+
+set(CFG_TEE_GROUP "tee" CACHE STRING "Group which has access to /dev/tee* devices")
+set(CFG_TEEPRIV_GROUP "teepriv" CACHE STRING "Group which has access to /dev/teepriv* devices")
+set(CFG_TEE_SUPPL_USER "teesuppl" CACHE STRING "User account which tee-supplicant is started with")
+set(CFG_TEE_SUPPL_GROUP "teesuppl" CACHE STRING "Group account which tee-supplicant is started with")
 
 if(CFG_TEE_SUPP_PLUGINS)
 	set(CMAKE_INSTALL_RPATH "${CFG_TEE_PLUGIN_LOAD_PATH}")
@@ -113,3 +118,7 @@ endif()
 # Install targets
 ################################################################################
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_SBINDIR})
+configure_file(tee-supplicant@.service.in tee-supplicant@.service @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/tee-supplicant@.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/system)
+configure_file(optee-udev.rules.in optee-udev.rules @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/optee-udev.rules DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/udev/rules.d)

--- a/tee-supplicant/optee-udev.rules.in
+++ b/tee-supplicant/optee-udev.rules.in
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-2-Clause
+KERNEL=="tee[0-9]*", MODE="0660", OWNER="root", GROUP="@CFG_TEE_GROUP@", TAG+="systemd"
+
+# If a /dev/teepriv[0-9]* device is detected, start an instance of
+# tee-supplicant.service with the device name as parameter
+KERNEL=="teepriv[0-9]*", MODE="0660", OWNER="root", GROUP="@CFG_TEEPRIV_GROUP@", \
+    TAG+="systemd", ENV{SYSTEMD_WANTS}+="tee-supplicant@%k.service"

--- a/tee-supplicant/tee-supplicant@.service.in
+++ b/tee-supplicant/tee-supplicant@.service.in
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-2-Clause
+[Unit]
+Description=TEE Supplicant on %i
+DefaultDependencies=no
+After=dev-%i.device
+Wants=dev-%i.device
+Conflicts=shutdown.target
+Before=tpm2.target sysinit.target shutdown.target
+
+[Service]
+Type=notify
+User=@CFG_TEE_SUPPL_USER@
+Group=@CFG_TEE_SUPPL_GROUP@
+EnvironmentFile=-@CMAKE_INSTALL_SYSCONFDIR@/default/tee-supplicant
+ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_SBINDIR@/tee-supplicant $OPTARGS
+# Workaround for fTPM TA: stop kernel module before tee-supplicant
+ExecStop=-/bin/sh -c "/sbin/modprobe -v -r tpm_ftpm_tee ; /bin/kill $MAINPID"


### PR DESCRIPTION
tee-supplicant startup with systemd init based
is non-trivial. Add needed udev rule and systemd
service files here so that distros can co-operate maintaining them.

Files are from meta-arm https://git.yoctoproject.org/meta-arm at commit 7cce43e632daa8650f683ac726f9124681b302a4 with license MIT and authors:

Peter Griffin <peter.griffin@linaro.org>
Joshua Watt <JPEWhacker@gmail.com>
Javier Tia <javier.tia@linaro.org>
Mikko Rapeli <mikko.rapeli@linaro.org>

The udev rule starts tee-supplicant once optee has been detected via /dev/teepriv[0-9]* device file. The startup expects to find teeclnt system group on the running host. systemd service starts before tpm2.target (new in systemd 256) which starts in initramfs too. This covers firmware TPM TA usecases, and possibly others which are started before main rootfs is mounted. For stopping tee-supplicant, the ftpm kernel modules are removed and only then the main process stopped to avoid fTPM breakage. These workarounds may be removed once RPMB kernel and optee patches
without tee-supplicant are merged.

Cc: Peter Griffin <peter.griffin@linaro.org>
Cc: Joshua Watt <JPEWhacker@gmail.com>
Cc: Javier Tia <javier.tia@linaro.org>