### PR TITLE
Validate EdDSA mechanism parameter length

### DIFF
--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -674,6 +674,23 @@ static CK_RV serialize_mecha_eddsa(struct serializer *obj,
 {
 	CK_RV rv = CKR_GENERAL_ERROR;
 	CK_EDDSA_PARAMS *params = mecha->pParameter;
+	CK_ULONG params_len = mecha->ulParameterLen;
+	/*
+	 * When no parameter is provided, the expected operation is
+	 * no-prehash and no-context.
+	 */
+	CK_EDDSA_PARAMS default_params = {
+		.phFlag = 0,
+		.ulContextDataLen = 0,
+	};
+
+	if (params_len == 0) {
+		params = &default_params;
+		params_len = sizeof(*params);
+	}
+
+	if (params_len != sizeof(*params))
+		return CKR_ARGUMENTS_BAD;
 
 	rv = serialize_32b(obj, obj->type);
 	if (rv)


### PR DESCRIPTION
I run into an segmentation fault when using following command:

`$ pkcs11-tool --module /usr/lib/libckteec.so.0 --login --sign -m EDDSA --slot 0 --id 01 --input-file /tmp/data --output-file /tmp/data.sig`

After bit of digging I found out that there is no parameterLen validation in EdDSA mechanism branch which result in null pointer dereference.

This fixes Segmentation fault when no parameter is provided as specified in pkcs11 v3.0 spec for Ed25519 Signature Scheme
