### PR TITLE
tee-supplicant: remove unused TEE_FS_FILENAME_MAX_LENGTH

### DIFF
--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -54,8 +54,6 @@
 /* Path to all secure storage files. */
 static char tee_fs_root[PATH_MAX];
 
-#define TEE_FS_FILENAME_MAX_LENGTH 150
-
 static pthread_mutex_t dir_handle_db_mutex = PTHREAD_MUTEX_INITIALIZER;
 static struct handle_db dir_handle_db =
 		HANDLE_DB_INITIALIZER_WITH_MUTEX(&dir_handle_db_mutex);


### PR DESCRIPTION
The TEE_FS_FILENAME_MAX_LENGTH is not used anywhere so remove it.