### PR TITLE
cmake: raise mimimum required to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 project(optee_client C)
 
 # https://cmake.org/Wiki/CMake_Useful_Variables


### PR DESCRIPTION
[CMake 4.0 was released](https://www.kitware.com/cmake-4-0-0-available-for-download/) which dropped compatibility with versions older than 3.5.
Bump the minimum required version to 3.5, which was released 9 years ago.