### PR TITLE
tee-supplicant: clear whole rsp_frm buffer

### DIFF
--- a/tee-supplicant/src/rpmb.c
+++ b/tee-supplicant/src/rpmb.c
@@ -840,7 +840,7 @@ static uint32_t rpmb_data_req(int fd, struct rpmb_data_frame *req_frm,
 		/* Send result request frame */
 		cmd = &mcmd->cmds[1];
 		set_mmc_io_cmd(cmd, req_nfrm, MMC_WRITE_MULTIPLE_BLOCK, 1);
-		memset(rsp_frm, 0, 1);
+		memset(rsp_frm, 0, sizeof(*rsp_frm));
 		rsp_frm->msg_type = htons(RPMB_MSG_TYPE_REQ_RESULT_READ);
 		mmc_ioc_cmd_set_data((*cmd), (uintptr_t)rsp_frm);
 


### PR DESCRIPTION
Fix rpmb_data_req() for message types RPMB_MSG_TYPE_REQ_AUTH_KEY_PROGRAM
and RPMB_MSG_TYPE_REQ_AUTH_DATA_WRITE: the response frame must be cleared
fully before being used.

Signed-off-by: Sunny Chen <[sunny.chen@st.com](mailto:sunny.chen@st.com)>
Reviewed-by: Jerome Forissier <[jerome.forissier@linaro.org](mailto:jerome.forissier@linaro.org)>