### PR TITLE
github: update stale workflow to v10.0.0

### DIFF
--- a/.github/workflows/stales.yml
+++ b/.github/workflows/stales.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v4.1.0
+    - uses: actions/stale@v10.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked as a stale issue because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment, otherwise this issue will automatically be closed in 5 days. Note, that you can always re-open a closed issue at any time.'


### PR DESCRIPTION
Update actions/stale@v4.1.0 to the latest version (v10.0.0). One difference is that issues and PRs are closed by the bot as "not_planned" rather than "completed", which is the main reason for updating.