### PR TITLE
Fix the mmcblk[0-9]rpmb root-less access

### DIFF
--- a/tee-supplicant/optee-udev.rules.in
+++ b/tee-supplicant/optee-udev.rules.in
@@ -5,3 +5,6 @@ KERNEL=="tee[0-9]*", MODE="0660", OWNER="root", GROUP="@CFG_TEE_GROUP@", TAG+="s
 # tee-supplicant.service with the device name as parameter
 KERNEL=="teepriv[0-9]*", MODE="0660", OWNER="root", GROUP="@CFG_TEEPRIV_GROUP@", \
     TAG+="systemd", ENV{SYSTEMD_WANTS}+="tee-supplicant@%k.service"
+
+ACTION=="add", SUBSYSTEM=="mmc_rpmb", KERNEL=="mmcblk[0-9]rpmb", \
+    GROUP="@CFG_TEEPRIV_GROUP@"


### PR DESCRIPTION
Fix rootless tee-supplicant handling for RPMB use-case. The RPMB communcation fails badly if the in-kernel RPMB handling was not enabled and the rootless tee-supplicant is used because the default group for the /dev/mmcblk[0-9]rpmb is 'root'.

Set the group to same group used for /dev/teepriv[0-9] to fix this and to allow rootless tee-supplicant usage with legacy user-space RPMB handling.