### PR TITLE
tee-supplicant: add details for systemd startup procedure

### DIFF
--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CFG_TEE_FS_PARENT_PATH "${CMAKE_INSTALL_LOCALSTATEDIR}/lib/tee" CACHE STRING
 # FIXME: Why do we have if defined(CFG_GP_SOCKETS) && CFG_GP_SOCKETS == 1 in the c-file?
 set(CFG_GP_SOCKETS "1" CACHE STRING "Enable GlobalPlatform Socket API support")
 set(CFG_TEE_PLUGIN_LOAD_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/plugins/" CACHE STRING "tee-supplicant's plugins path")
+set(CFG_UDEV_RULESPREFIX "60-" CACHE STRING "Priority prefix for udev rule")
 
 set(CFG_TEE_GROUP "tee" CACHE STRING "Group which has access to /dev/tee* devices")
 set(CFG_TEEPRIV_GROUP "teepriv" CACHE STRING "Group which has access to /dev/teepriv* devices")
@@ -150,6 +151,6 @@ if (CFG_ENABLE_SYSTEMD)
 	install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/tee-supplicant@.service DESTINATION ${SYSTEMD_UNIT_DIR})
 endif()
 if (CFG_ENABLE_UDEV)
-	configure_file(optee-udev.rules.in optee-udev.rules @ONLY)
-	install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/optee-udev.rules DESTINATION ${UDEV_UDEV_DIR})
+	configure_file(optee-udev.rules.in ${CFG_UDEV_RULESPREFIX}optee-udev.rules @ONLY)
+	install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${CFG_UDEV_RULESPREFIX}optee-udev.rules DESTINATION ${UDEV_UDEV_DIR})
 endif()

--- a/tee-supplicant/tee-supplicant@.service.in
+++ b/tee-supplicant/tee-supplicant@.service.in
@@ -12,6 +12,6 @@ Type=notify
 User=@CFG_TEE_SUPPL_USER@
 Group=@CFG_TEE_SUPPL_GROUP@
 EnvironmentFile=-@CMAKE_INSTALL_SYSCONFDIR@/default/tee-supplicant
-ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_SBINDIR@/tee-supplicant $OPTARGS
+ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_SBINDIR@/tee-supplicant $OPTARGS /dev/%I
 # Workaround for fTPM TA: stop kernel module before tee-supplicant
 ExecStop=-/bin/sh -c "/sbin/modprobe -v -r tpm_ftpm_tee ; /bin/kill $MAINPID"


### PR DESCRIPTION
The current implementation lacks some details in order to work properly within the context of udev and systemd. The following patches aim to add these.