### PR TITLE
tee-supplicant: fix uninitialized data access if stat() fails

### DIFF
--- a/tee-supplicant/src/tee_supp_fs.c
+++ b/tee-supplicant/src/tee_supp_fs.c
@@ -105,7 +105,7 @@ static int do_mkdir(const char *path, mode_t mode)
 	if (mkdir(path, mode) != 0 && errno != EEXIST)
 		return -1;
 
-	if (stat(path, &st) != 0 && !S_ISDIR(st.st_mode))
+	if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode))
 		return -1;
 
 	return 0;


### PR DESCRIPTION
do_mkdir() shall not continue to S_ISDIR check with 'st' struct fields in case the stat() call has returned error, because the struct content may be uninitialized.