### PR TITLE
libckteec: fix integer overflow in PKCS#11 serializer

### DIFF
--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -173,6 +173,8 @@ static CK_RV serialize_ck_attribute(struct serializer *obj, CK_ATTRIBUTE *attr)
 		return serialize_indirect_attribute(obj, attr);
 	case CKA_ALLOWED_MECHANISMS:
 		n = attr->ulValueLen / sizeof(CK_ULONG);
+		if (n > UINT32_MAX / sizeof(uint32_t))
+			return CKR_ARGUMENTS_BAD;
 		pkcs11_size = n * sizeof(uint32_t);
 		mech_buf = malloc(pkcs11_size);
 		if (!mech_buf)

--- a/libckteec/src/serializer.c
+++ b/libckteec/src/serializer.c
@@ -45,7 +45,11 @@ void release_serial_object(struct serializer *obj)
 static CK_RV serialize(char **bstart, size_t *blen, void *data, size_t len)
 {
 	size_t nlen = *blen + len;
-	char *buf = realloc(*bstart, nlen);
+	char *buf = NULL;
+
+	if (nlen < *blen)
+		return CKR_ARGUMENTS_BAD;
+	buf = realloc(*bstart, nlen);
 
 	if (!buf)
 		return CKR_HOST_MEMORY;


### PR DESCRIPTION
Fix integer overflow in serialize() and serialize_ck_attribute() that could lead to heap buffer overflow via crafted PKCS#11 attributes.