### PR TITLE
libckteec: prevent integer overflow in shared memory allocations

### DIFF
--- a/libckteec/src/local_utils.h
+++ b/libckteec/src/local_utils.h
@@ -13,4 +13,190 @@
 		switch (0) { case 0: case ((x) ? 1: 0) : default : break; } \
 	} while (0)
 
+/*
+ * Checking overflow for addition, subtraction and multiplication. Result
+ * of operation is stored in res which is a pointer to some kind of
+ * integer.
+ *
+ * The macros return true if an overflow occurred and *res is undefined.
+ */
+#define ADD_OVERFLOW(a, b, res) __compiler_add_overflow((a), (b), (res))
+#define SUB_OVERFLOW(a, b, res) __compiler_sub_overflow((a), (b), (res))
+#define MUL_OVERFLOW(a, b, res) __compiler_mul_overflow((a), (b), (res))
+
+#define __GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + \
+		       __GNUC_PATCHLEVEL__)
+
+#if __GCC_VERSION >= 50100 && !defined(__CHECKER__)
+#define __HAVE_BUILTIN_OVERFLOW 1
+#endif
+
+#if __GCC_VERSION >= 90100 && !defined(__CHECKER__)
+#define __HAVE_SINGLE_ARGUMENT_STATIC_ASSERT 1
+#endif
+
+#ifdef __HAVE_BUILTIN_OVERFLOW
+#define __compiler_add_overflow(a, b, res) \
+	__builtin_add_overflow((a), (b), (res))
+
+#define __compiler_sub_overflow(a, b, res) \
+	__builtin_sub_overflow((a), (b), (res))
+
+#define __compiler_mul_overflow(a, b, res) \
+	__builtin_mul_overflow((a), (b), (res))
+#else /*!__HAVE_BUILTIN_OVERFLOW*/
+
+/*
+ * Copied/inspired from https://www.fefe.de/intof.html
+ */
+
+#define __INTOF_ASSIGN(dest, src) (__extension__({ \
+	typeof(src) __intof_x = (src); \
+	typeof(dest) __intof_y = __intof_x; \
+	(((uintmax_t)__intof_x == (uintmax_t)__intof_y) && \
+	 ((__intof_x < 1) == (__intof_y < 1)) ? \
+		(void)((dest) = __intof_y) , 0 : 1); \
+}))
+
+#define __INTOF_ADD(c, a, b) (__extension__({ \
+	typeof(a) __intofa_a = (a); \
+	typeof(b) __intofa_b = (b); \
+	intmax_t __intofa_a_signed = __intofa_a; \
+	uintmax_t __intofa_a_unsigned = __intofa_a; \
+	intmax_t __intofa_b_signed = __intofa_b; \
+	uintmax_t __intofa_b_unsigned = __intofa_b; \
+	\
+	__intofa_b < 1 ? \
+		__intofa_a < 1 ? \
+			((INTMAX_MIN - __intofa_b_signed <= \
+			  __intofa_a_signed)) ? \
+				__INTOF_ASSIGN((c), __intofa_a_signed + \
+						    __intofa_b_signed) : 1 \
+		: \
+			((__intofa_a_unsigned >= (uintmax_t)-__intofa_b) ? \
+				__INTOF_ASSIGN((c), __intofa_a_unsigned + \
+						    __intofa_b_signed) \
+			: \
+				__INTOF_ASSIGN((c), \
+					(intmax_t)(__intofa_a_unsigned + \
+						   __intofa_b_signed))) \
+	: \
+		__intofa_a < 1 ? \
+			((__intofa_b_unsigned >= (uintmax_t)-__intofa_a) ? \
+				__INTOF_ASSIGN((c), __intofa_a_signed + \
+						    __intofa_b_unsigned) \
+			: \
+				__INTOF_ASSIGN((c), \
+					(intmax_t)(__intofa_a_signed + \
+						   __intofa_b_unsigned))) \
+		: \
+			((UINTMAX_MAX - __intofa_b_unsigned >= \
+			  __intofa_a_unsigned) ? \
+				__INTOF_ASSIGN((c), __intofa_a_unsigned + \
+						    __intofa_b_unsigned) : 1); \
+}))
+
+#define __INTOF_SUB(c, a, b) (__extension__({ \
+	typeof(a) __intofs_a = a; \
+	typeof(b) __intofs_b = b; \
+	intmax_t __intofs_a_signed = __intofs_a; \
+	uintmax_t __intofs_a_unsigned = __intofs_a; \
+	intmax_t __intofs_b_signed = __intofs_b; \
+	uintmax_t __intofs_b_unsigned = __intofs_b; \
+	\
+	__intofs_b < 1 ? \
+		__intofs_a < 1 ? \
+			((INTMAX_MAX + __intofs_b_signed >= \
+			  __intofs_a_signed) ? \
+				__INTOF_ASSIGN((c), __intofs_a_signed - \
+						    __intofs_b_signed) : 1) \
+		: \
+			(((uintmax_t)(UINTMAX_MAX + __intofs_b_signed) >= \
+			  __intofs_a_unsigned) ? \
+				__INTOF_ASSIGN((c), __intofs_a - \
+						    __intofs_b) : 1) \
+	: \
+		__intofs_a < 1 ? \
+			(((intmax_t)(INTMAX_MIN + __intofs_b) <= \
+			  __intofs_a_signed) ? \
+				__INTOF_ASSIGN((c), \
+					(intmax_t)(__intofs_a_signed - \
+						   __intofs_b_unsigned)) : 1) \
+		: \
+			((__intofs_b_unsigned <= __intofs_a_unsigned) ? \
+				__INTOF_ASSIGN((c), __intofs_a_unsigned - \
+						    __intofs_b_unsigned) \
+			: \
+				__INTOF_ASSIGN((c), \
+					(intmax_t)(__intofs_a_unsigned - \
+						   __intofs_b_unsigned))); \
+}))
+
+/*
+ * Dealing with detecting overflow in multiplication of integers.
+ *
+ * First step is to remove two corner cases with the minum signed integer
+ * which can't be represented as a positive integer + sign.
+ * Multiply with 0 or 1 can't overflow, no checking needed of the operation,
+ * only if it can be assigned to the result.
+ *
+ * After the corner cases are eliminated we convert the two factors to
+ * positive unsigned values, keeping track of the original in another
+ * variable which is used at the end to determine the sign of the product.
+ *
+ * The two terms (a and b) are divided into upper and lower half (x1 upper
+ * and x0 lower), so the product is:
+ * ((a1 << hshift) + a0) * ((b1 << hshift) + b0)
+ * which also is:
+ * ((a1 * b1) << (hshift * 2)) +				(T1)
+ * ((a1 * b0 + a0 * b1) << hshift) +				(T2)
+ * (a0 * b0)							(T3)
+ *
+ * From this we can tell and (a1 * b1) has to be 0 or we'll overflow, that
+ * is, at least one of a1 or b1 has to be 0. Once this has been checked the
+ * addition: ((a1 * b0) << hshift) + ((a0 * b1) << hshift)
+ * isn't an addition as one of the terms will be 0.
+ *
+ * Since each factor in: (a0 * b0)
+ * only uses half the capicity of the underlaying type it can't overflow
+ *
+ * The addition of T2 and T3 can overflow so we use __INTOF_ADD() to
+ * perform that addition. If the addition succeeds without overflow the
+ * result is assigned the required sign and checked for overflow again.
+ */
+
+#define __intof_mul_negate	((__intof_oa < 1) != (__intof_ob < 1))
+#define __intof_mul_hshift	(sizeof(uintmax_t) * 8 / 2)
+#define __intof_mul_hmask	(UINTMAX_MAX >> __intof_mul_hshift)
+#define __intof_mul_a0		((uintmax_t)(__intof_a) >> __intof_mul_hshift)
+#define __intof_mul_b0		((uintmax_t)(__intof_b) >> __intof_mul_hshift)
+#define __intof_mul_a1		((uintmax_t)(__intof_a) & __intof_mul_hmask)
+#define __intof_mul_b1		((uintmax_t)(__intof_b) & __intof_mul_hmask)
+#define __intof_mul_t		(__intof_mul_a1 * __intof_mul_b0 + \
+				 __intof_mul_a0 * __intof_mul_b1)
+
+#define __INTOF_MUL(c, a, b) (__extension__({ \
+	typeof(a) __intof_oa = (a); \
+	typeof(a) __intof_a = __intof_oa < 1 ? -__intof_oa : __intof_oa; \
+	typeof(b) __intof_ob = (b); \
+	typeof(b) __intof_b = __intof_ob < 1 ? -__intof_ob : __intof_ob; \
+	typeof(c) __intof_c; \
+	\
+	__intof_oa == 0 || __intof_ob == 0 || \
+	__intof_oa == 1 || __intof_ob == 1 ? \
+		__INTOF_ASSIGN((c), __intof_oa * __intof_ob) : \
+	(__intof_mul_a0 && __intof_mul_b0) || \
+	 __intof_mul_t > __intof_mul_hmask ?  1 : \
+	__INTOF_ADD((__intof_c), __intof_mul_t << __intof_mul_hshift, \
+				 __intof_mul_a1 * __intof_mul_b1) ? 1 : \
+	__intof_mul_negate ? __INTOF_ASSIGN((c), -__intof_c) : \
+			     __INTOF_ASSIGN((c), __intof_c); \
+}))
+
+#define __compiler_add_overflow(a, b, res) __INTOF_ADD(*(res), (a), (b))
+#define __compiler_sub_overflow(a, b, res) __INTOF_SUB(*(res), (a), (b))
+#define __compiler_mul_overflow(a, b, res) __INTOF_MUL(*(res), (a), (b))
+
+#endif /*!__HAVE_BUILTIN_OVERFLOW*/
+
 #endif /*LIBCKTEEC_LOCAL_UTILS_H*/

--- a/libckteec/src/pkcs11_processing.c
+++ b/libckteec/src/pkcs11_processing.c
@@ -12,6 +12,7 @@
 
 #include "pkcs11_processing.h"
 #include "invoke_ta.h"
+#include "local_utils.h"
 #include "serializer.h"
 #include "serialize_ck.h"
 
@@ -36,7 +37,11 @@ CK_RV ck_create_object(CK_SESSION_HANDLE session, CK_ATTRIBUTE_PTR attribs,
 		goto out;
 
 	/* Shm io0: (i/o) [session-handle][serialized-attributes] / [status] */
-	ctrl_size = sizeof(session_handle) + obj.size;
+	if (ADD_OVERFLOW(sizeof(session_handle), obj.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto out;
+	}
+
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
 		rv = CKR_HOST_MEMORY;
@@ -132,7 +137,11 @@ CK_RV ck_encdecrypt_init(CK_SESSION_HANDLE session,
 	 * (in) [session-handle][key-handle][serialized-mechanism-blob]
 	 * (out) [status]
 	 */
-	ctrl_size = sizeof(session_handle) + sizeof(key_handle) + obj.size;
+	ctrl_size = sizeof(session_handle) + sizeof(key_handle);
+	if (ADD_OVERFLOW(ctrl_size, obj.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
@@ -388,7 +397,11 @@ CK_RV ck_digest_init(CK_SESSION_HANDLE session, CK_MECHANISM_PTR mechanism)
 	 * (in) [session-handle][serialized-mechanism-blob]
 	 * (out) [status]
 	 */
-	ctrl_size = sizeof(session_handle) + obj.size;
+	if (ADD_OVERFLOW(sizeof(session_handle), obj.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
+
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
 		rv = CKR_HOST_MEMORY;
@@ -656,7 +669,12 @@ CK_RV ck_signverify_init(CK_SESSION_HANDLE session,
 	 * (in) [session-handle][key-handle][serialized-mechanism-blob]
 	 * (out) [status]
 	 */
-	ctrl_size = sizeof(session_handle) + sizeof(key_handle) + obj.size;
+	ctrl_size = sizeof(session_handle) + sizeof(key_handle);
+	if (ADD_OVERFLOW(ctrl_size, obj.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
+
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
 		rv = CKR_HOST_MEMORY;
@@ -902,7 +920,11 @@ CK_RV ck_generate_key(CK_SESSION_HANDLE session,
 	 * (in) [session-handle][serialized-mecha][serialized-attributes]
 	 * (out) [status]
 	 */
-	ctrl_size = sizeof(session_handle) + smecha.size + sattr.size;
+	if (ADD_OVERFLOW(sizeof(session_handle), smecha.size, &ctrl_size) ||
+	    ADD_OVERFLOW(ctrl_size, sattr.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
@@ -970,7 +992,11 @@ CK_RV ck_find_objects_init(CK_SESSION_HANDLE session,
 	 * (in) [session-handle][headed-serialized-attributes]
 	 * (out) [status]
 	 */
-	ctrl_size = sizeof(session_handle) + obj.size;
+	if (ADD_OVERFLOW(sizeof(session_handle), obj.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
+
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
 		rv = CKR_HOST_MEMORY;
@@ -1004,12 +1030,15 @@ CK_RV ck_find_objects(CK_SESSION_HANDLE session,
 	TEEC_SharedMemory *out_shm = NULL;
 	uint32_t session_handle = session;
 	uint32_t *handles = NULL;
-	size_t handles_size = max_count * sizeof(uint32_t);
+	size_t handles_size = 0;
 	CK_ULONG n = 0;
 	CK_ULONG last = 0;
 	size_t out_size = 0;
 
 	if (!count || (max_count && !obj))
+		return CKR_ARGUMENTS_BAD;
+
+	if (MUL_OVERFLOW(max_count, sizeof(uint32_t), &handles_size))
 		return CKR_ARGUMENTS_BAD;
 
 	/* Shm io0: (in/out) ctrl = [session-handle] / [status] */
@@ -1154,7 +1183,11 @@ CK_RV ck_get_attribute_value(CK_SESSION_HANDLE session,
 		goto bail;
 
 	/* Shm io0: (in/out) [session][obj-handle][attributes] / [status] */
-	ctrl_size = sizeof(session_handle) + sizeof(obj_handle) + sattr.size;
+	ctrl_size = sizeof(session_handle) + sizeof(obj_handle);
+	if (ADD_OVERFLOW(ctrl_size, sattr.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
@@ -1219,7 +1252,11 @@ CK_RV ck_set_attribute_value(CK_SESSION_HANDLE session,
 		goto bail;
 
 	/* Shm io0: (in/out) [session][obj-handle][attributes] / [status] */
-	ctrl_size = sizeof(session_handle) + sizeof(obj_handle) + sattr.size;
+	ctrl_size = sizeof(session_handle) + sizeof(obj_handle);
+	if (ADD_OVERFLOW(ctrl_size, sattr.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
@@ -1271,7 +1308,11 @@ CK_RV ck_copy_object(CK_SESSION_HANDLE session,
 		goto bail;
 
 	/* Shm io0: (in/out) [session][obj-handle][attributes] / [status] */
-	ctrl_size = sizeof(session_handle) + sizeof(obj_handle) + sattr.size;
+	ctrl_size = sizeof(session_handle) + sizeof(obj_handle);
+	if (ADD_OVERFLOW(ctrl_size, sattr.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
@@ -1350,8 +1391,12 @@ CK_RV ck_derive_key(CK_SESSION_HANDLE session,
 	 * (in) [session-handle][obj-handle][serialized-mecha][serialized-attributes]
 	 * (out) [status]
 	 */
-	ctrl_size = sizeof(session_handle) + sizeof(obj_handle) + smecha.size +
-		    sattr.size;
+	ctrl_size = sizeof(session_handle) + sizeof(obj_handle);
+	if (ADD_OVERFLOW(ctrl_size, smecha.size, &ctrl_size) ||
+	    ADD_OVERFLOW(ctrl_size, sattr.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
@@ -1474,8 +1519,12 @@ CK_RV ck_generate_key_pair(CK_SESSION_HANDLE session,
 	 *      [serialized-priv_attribs]
 	 * (out) [status]
 	 */
-	ctrl_size = sizeof(session_handle) + smecha.size + pub_sattr.size +
-		    priv_sattr.size;
+	if (ADD_OVERFLOW(sizeof(session_handle), smecha.size, &ctrl_size) ||
+	    ADD_OVERFLOW(ctrl_size, pub_sattr.size, &ctrl_size) ||
+	    ADD_OVERFLOW(ctrl_size, priv_sattr.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
@@ -1557,7 +1606,11 @@ CK_RV ck_wrap_key(CK_SESSION_HANDLE session, CK_MECHANISM_PTR mechanism,
 	 * (out) [status]
 	 */
 	ctrl_size = sizeof(session_handle) + sizeof(wrp_key_handle) +
-		    sizeof(key_handle) + smecha.size;
+		    sizeof(key_handle);
+	if (ADD_OVERFLOW(ctrl_size, smecha.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {
@@ -1647,8 +1700,12 @@ CK_RV ck_unwrap_key(CK_SESSION_HANDLE session, CK_MECHANISM_PTR mechanism,
 	 *      [serialized-attributes]
 	 * (out) [status]
 	 */
-	ctrl_size = sizeof(session_handle) + sizeof(unwrapping_key_handle) +
-		    smecha.size + sattr.size;
+	ctrl_size = sizeof(session_handle) + sizeof(unwrapping_key_handle);
+	if (ADD_OVERFLOW(ctrl_size, smecha.size, &ctrl_size) ||
+	    ADD_OVERFLOW(ctrl_size, sattr.size, &ctrl_size)) {
+		rv = CKR_ARGUMENTS_BAD;
+		goto bail;
+	}
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl) {

--- a/libckteec/src/pkcs11_token.c
+++ b/libckteec/src/pkcs11_token.c
@@ -100,7 +100,8 @@ CK_RV ck_slot_get_list(CK_BBOOL present,
 	if (slots)
 		client_count = *count;
 
-	size = client_count * sizeof(*slot_ids);
+	if (MUL_OVERFLOW(client_count, sizeof(*slot_ids), &size))
+		return CKR_ARGUMENTS_BAD;
 
 	shm = ckteec_alloc_shm(size, CKTEEC_SHM_OUT);
 	if (!shm)
@@ -307,8 +308,8 @@ CK_RV ck_token_mechanism_ids(CK_SLOT_ID slot,
 	 * As per spec, if @mechanism is NULL, "The contents of *pulCount on
 	 * entry to C_GetMechanismList has no meaning in this case (...)"
 	 */
-	if (mechanisms)
-		out_size = *count * sizeof(*mecha_ids);
+	if (mechanisms && MUL_OVERFLOW(*count, sizeof(*mecha_ids), &out_size))
+		return CKR_ARGUMENTS_BAD;
 
 	ctrl = ckteec_alloc_shm(sizeof(slot_id), CKTEEC_SHM_INOUT);
 	if (!ctrl) {
@@ -593,7 +594,9 @@ CK_RV ck_init_token(CK_SLOT_ID slot, CK_UTF8CHAR_PTR pin,
 
 	/* Shm io0: (in/out) ctrl = [slot-id][pin_len][label][pin] / [status] */
 	ctrl_size = sizeof(slot_id) + sizeof(pkcs11_pin_len) +
-		    32 * sizeof(uint8_t) + pkcs11_pin_len;
+		    32 * sizeof(uint8_t);
+	if (ADD_OVERFLOW(ctrl_size, pkcs11_pin_len, &ctrl_size))
+		return CKR_ARGUMENTS_BAD;
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl)
@@ -636,8 +639,9 @@ CK_RV ck_init_pin(CK_SESSION_HANDLE session,
 		return CKR_ARGUMENTS_BAD;
 
 	/* Shm io0: (in/out) ctrl = [session][pin_len][pin] / [status] */
-	ctrl_size = sizeof(pkcs11_session) + sizeof(pkcs11_pin_len) +
-		    pkcs11_pin_len;
+	ctrl_size = sizeof(pkcs11_session) + sizeof(pkcs11_pin_len);
+	if (ADD_OVERFLOW(ctrl_size, pkcs11_pin_len, &ctrl_size))
+		return CKR_ARGUMENTS_BAD;
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl)
@@ -684,7 +688,10 @@ CK_RV ck_set_pin(CK_SESSION_HANDLE session,
 	 * (out) [status]
 	 */
 	ctrl_size = sizeof(pkcs11_session) + sizeof(pkcs11_old_len) +
-		    sizeof(pkcs11_new_len) + pkcs11_old_len + pkcs11_new_len;
+		    sizeof(pkcs11_new_len);
+	if (ADD_OVERFLOW(ctrl_size, pkcs11_old_len, &ctrl_size) ||
+	    ADD_OVERFLOW(ctrl_size, pkcs11_new_len, &ctrl_size))
+		return CKR_ARGUMENTS_BAD;
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl)
@@ -733,7 +740,9 @@ CK_RV ck_login(CK_SESSION_HANDLE session, CK_USER_TYPE user_type,
 
 	/* Shm io0: (i/o) ctrl = [session][user][pin length][pin] / [status] */
 	ctrl_size = sizeof(pkcs11_session) + sizeof(pkcs11_user) +
-		    sizeof(pkcs11_pin_len) + pkcs11_pin_len;
+		    sizeof(pkcs11_pin_len);
+	if (ADD_OVERFLOW(ctrl_size, pkcs11_pin_len, &ctrl_size))
+		return CKR_ARGUMENTS_BAD;
 
 	ctrl = ckteec_alloc_shm(ctrl_size, CKTEEC_SHM_INOUT);
 	if (!ctrl)

--- a/libckteec/src/serialize_ck.c
+++ b/libckteec/src/serialize_ck.c
@@ -419,6 +419,7 @@ static CK_RV serialize_mecha_aes_gcm(struct serializer *obj,
 	CK_GCM_PARAMS_PTR param = mecha->pParameter;
 	CK_RV rv = CKR_GENERAL_ERROR;
 	CK_ULONG aad_len = 0;
+	uint32_t data32 = 0;
 
 	/* AAD is not manadatory */
 	if (param->pAAD)
@@ -431,8 +432,12 @@ static CK_RV serialize_mecha_aes_gcm(struct serializer *obj,
 	if (rv)
 		return rv;
 
-	rv = serialize_32b(obj, 3 * sizeof(uint32_t) +
-				param->ulIvLen + aad_len);
+	data32 = 3 * sizeof(uint32_t);
+	if (ADD_OVERFLOW(data32, param->ulIvLen, &data32) ||
+	    ADD_OVERFLOW(data32, aad_len, &data32))
+		return CKR_ARGUMENTS_BAD;
+
+	rv = serialize_32b(obj, data32);
 	if (rv)
 		return rv;
 
@@ -500,8 +505,12 @@ static CK_RV serialize_mecha_ecdh1_derive_param(struct serializer *obj,
 {
 	CK_ECDH1_DERIVE_PARAMS *params = mecha->pParameter;
 	CK_RV rv = CKR_GENERAL_ERROR;
-	size_t params_size = 3 * sizeof(uint32_t) + params->ulSharedDataLen +
-			     params->ulPublicDataLen;
+	size_t params_size = 0;
+
+	params_size = 3 * sizeof(uint32_t);
+	if (ADD_OVERFLOW(params_size, params->ulSharedDataLen, &params_size) ||
+	    ADD_OVERFLOW(params_size, params->ulPublicDataLen, &params_size))
+		return CKR_ARGUMENTS_BAD;
 
 	rv = serialize_32b(obj, obj->type);
 	if (rv)
@@ -539,11 +548,14 @@ static CK_RV serialize_mecha_aes_cbc_encrypt_data(struct serializer *obj,
 	CK_RV rv = CKR_GENERAL_ERROR;
 	uint32_t size = 0;
 
+	if (ADD_OVERFLOW(sizeof(param->iv) + sizeof(uint32_t),
+			 param->length, &size))
+		return CKR_ARGUMENTS_BAD;
+
 	rv = serialize_32b(obj, obj->type);
 	if (rv)
 		return rv;
 
-	size = sizeof(param->iv) + sizeof(uint32_t) + param->length;
 	rv = serialize_32b(obj, size);
 	if (rv)
 		return rv;
@@ -593,7 +605,11 @@ static CK_RV serialize_mecha_rsa_oaep_param(struct serializer *obj,
 {
 	CK_RSA_PKCS_OAEP_PARAMS *params = mecha->pParameter;
 	CK_RV rv = CKR_GENERAL_ERROR;
-	size_t params_size = 4 * sizeof(uint32_t) + params->ulSourceDataLen;
+	size_t params_size = 0;
+
+	params_size = 4 * sizeof(uint32_t);
+	if (ADD_OVERFLOW(params_size, params->ulSourceDataLen, &params_size))
+		return CKR_ARGUMENTS_BAD;
 
 	if (mecha->ulParameterLen != sizeof(*params))
 		return CKR_ARGUMENTS_BAD;
@@ -632,7 +648,11 @@ static CK_RV serialize_mecha_rsa_aes_key_wrap(struct serializer *obj,
 	CK_RSA_AES_KEY_WRAP_PARAMS *params = mecha->pParameter;
 	CK_RSA_PKCS_OAEP_PARAMS *aes_params = params->pOAEPParams;
 	CK_RV rv = CKR_GENERAL_ERROR;
-	size_t params_size = 5 * sizeof(uint32_t) + aes_params->ulSourceDataLen;
+	size_t params_size = 0;
+
+	if (ADD_OVERFLOW(5 * sizeof(uint32_t), aes_params->ulSourceDataLen,
+			 &params_size))
+		return CKR_ARGUMENTS_BAD;
 
 	if (mecha->ulParameterLen != sizeof(*params))
 		return CKR_ARGUMENTS_BAD;
@@ -683,6 +703,7 @@ static CK_RV serialize_mecha_eddsa(struct serializer *obj,
 		.phFlag = 0,
 		.ulContextDataLen = 0,
 	};
+	uint32_t data32 = 0;
 
 	if (params_len == 0) {
 		params = &default_params;
@@ -692,11 +713,15 @@ static CK_RV serialize_mecha_eddsa(struct serializer *obj,
 	if (params_len != sizeof(*params))
 		return CKR_ARGUMENTS_BAD;
 
+	if (ADD_OVERFLOW(2 * sizeof(uint32_t), params->ulContextDataLen,
+			 &data32))
+		return CKR_ARGUMENTS_BAD;
+
 	rv = serialize_32b(obj, obj->type);
 	if (rv)
 		return rv;
 
-	rv = serialize_32b(obj, 2 * sizeof(uint32_t) + params->ulContextDataLen);
+	rv = serialize_32b(obj, data32);
 	if (rv)
 		return rv;
 

--- a/libckteec/src/serializer.c
+++ b/libckteec/src/serializer.c
@@ -44,9 +44,13 @@ void release_serial_object(struct serializer *obj)
  */
 static CK_RV serialize(char **bstart, size_t *blen, void *data, size_t len)
 {
-	size_t nlen = *blen + len;
-	char *buf = realloc(*bstart, nlen);
+	size_t nlen = 0;
+	char *buf = NULL;
 
+	if (ADD_OVERFLOW(*blen, len, &nlen))
+		return CKR_ARGUMENTS_BAD;
+
+	buf = realloc(*bstart, nlen);
 	if (!buf)
 		return CKR_HOST_MEMORY;
 


### PR DESCRIPTION
Fixes integer overflow in several libckteec callers of ckteec_alloc_shm() and in the PKCS#11 serializer.
